### PR TITLE
Fix prompt creation in oracle.plan(...)

### DIFF
--- a/refuel_oracle/oracle.py
+++ b/refuel_oracle/oracle.py
@@ -124,7 +124,10 @@ class Oracle:
             for i, input_i in enumerate(chunk):
                 if (i + 1) % 10 == 0:
                     print(f"{i+1}/{len(input)}...")
-                final_prompt = self.construct_final_prompt(input_i)
+                # Fetch few-shot seed examples
+                examples = self.config["seed_examples"]
+
+                final_prompt = self.task.construct_prompt(input_i, examples)
                 num_tokens = calculate_num_tokens(
                     self.config, final_prompt
                 )


### PR DESCRIPTION
```
Python 3.8.9 (default, Aug  3 2021, 19:21:54)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.31.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import os
   ...: os.environ["OPENAI_API_KEY"] = "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"

In [2]: from refuel_oracle.oracle import Oracle

In [3]: o = Oracle('examples/config2.json', debug=True)

In [4]: o.plan('examples/ag_news_filtered_labels_sampled.csv', input_column='description')
Total Estimated Cost: 22.13184
Number of examples to label: 2997
Average cost per example: 0.0073846646646646644

In [5]: quit()
```