### PR TITLE
Add support for langchain ChatModels, and ChatGPT 3.5 turbo

### DIFF
--- a/examples/config_chatgpt.json
+++ b/examples/config_chatgpt.json
@@ -1,0 +1,37 @@
+{
+    "project_name": "AG News classification",
+    "task_type": "classification",
+    "provider_name": "openai_chat",
+    "model_name": "gpt-3.5-turbo",
+    "model_params": {},
+    "prefix_prompt": "You are an expert at understanding news articles.",
+    "labels_list": [
+        "Sports",
+        "Health",
+        "Business",
+        "Entertainment",
+        "Sci/Tech",
+        "Italia",
+        "Software",
+        "Music Feeds",
+        "Toons"
+    ],
+    "seed_examples": [
+        {
+            "example": "The NHL and the players' association appeared headed toward a lockout when talks broke off yesterday after the union's first new proposal in nearly a year.",
+            "output": "Sports"
+        },
+        {
+            "example": "Computer Associates International Inc. said Monday it has revoked home security and office support benefits to former Chief Executive Officer Sanjay Kumar, who was indicted last week on",
+            "output": "Business"
+        },
+        {
+            "example": "Big Blue adds \"innovaton center\" to its China Research Lab to develop technology catering to small and midsize businesses.",
+            "output": "Sci/Tech"
+        },
+        {
+            "example": "Before you wear your your cool yellow LiveStrong wristband at the hospital, think twice. Morton Plant Mease hospitals, St. Joseph #39;s and St Anthony #39;s are putting the brakes on Lance Armstrong #39;s",
+            "output": "Health"
+        }
+    ]
+}

--- a/refuel_oracle/llm.py
+++ b/refuel_oracle/llm.py
@@ -1,11 +1,18 @@
 import copy
-from typing import Dict
+from typing import Dict, List
 from enum import Enum
+from langchain.chat_models import ChatOpenAI
 from langchain.llms import (
     Anthropic,
     BaseLLM,
     Cohere,
     OpenAI
+)
+from langchain.schema import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    LLMResult
 )
 
 from refuel_oracle.config import Config
@@ -13,33 +20,57 @@ from refuel_oracle.config import Config
 # All available LLM providers
 class LLMProvider(str, Enum):
     openai = "openai"
+    openai_chat = "openai_chat"
     anthropic = "anthropic"
     cohere = "cohere"
 
-# Default parameters that we will use to initialize LLMs from a provider
-PROVIDER_TO_DEFAULT_PARAMS = {
-    LLMProvider.openai: {
-        "max_tokens": 30,
-        "temperature": 0.0,
-        "model_kwargs": {"logprobs": 1}
-    },
-    LLMProvider.cohere: {
-        # TODO
-    },
-    LLMProvider.anthropic: {
-        # TODO
-    }
-}
 
-# Provider mapping to the langchain LLM wrapper
-PROVIDER_TO_LLM = {
-    LLMProvider.anthropic: Anthropic,
-    LLMProvider.cohere: Cohere,
-    LLMProvider.openai: OpenAI,
-}
+class LLMLabeler:
+    def __init__(self, config: Config, base_llm: BaseLLM) -> None:
+        self.config = config
+        self.base_llm = base_llm
+    
+    def is_chat_model(self, llm_provider: LLMProvider) -> bool:
+        # Add more models here that are in `langchain.chat_models.*`
+        return llm_provider == LLMProvider.openai_chat
 
+    def generate(self, prompts: List) -> LLMResult:
+        llm_provider = self.config.get_provider()
+        if self.is_chat_model(llm_provider):
+            # Need to convert list[prompts] -> list[messages]
+            # Currently the entire prompt is stuck into the "human message"
+            # We might consider breaking this up into human vs system message in future
+            prompts = [[HumanMessage(content=prompt)] for prompt in prompts]
+        return self.base_llm.generate(prompts)
 
 class LLMFactory:
+
+    # Default parameters that we will use to initialize LLMs from a provider
+    PROVIDER_TO_DEFAULT_PARAMS = {
+        LLMProvider.openai: {
+            "max_tokens": 30,
+            "temperature": 0.0,
+            "model_kwargs": {"logprobs": 1}
+        },
+        LLMProvider.openai_chat: {
+            "max_tokens": 30,
+            "temperature": 0.0,
+        },
+        LLMProvider.cohere: {
+            # TODO
+        },
+        LLMProvider.anthropic: {
+            # TODO
+        }
+    }
+
+    # Provider mapping to the langchain LLM wrapper
+    PROVIDER_TO_LLM = {
+        LLMProvider.anthropic: Anthropic,
+        LLMProvider.cohere: Cohere,
+        LLMProvider.openai: OpenAI,
+        LLMProvider.openai_chat: ChatOpenAI
+    }
 
     @staticmethod
     def _resolve_params(default_params: Dict, provided_params: Dict) -> Dict:
@@ -52,18 +83,18 @@ class LLMFactory:
         return final_params
 
     @staticmethod
-    def from_config(config: Config) -> BaseLLM:
+    def from_config(config: Config) -> LLMLabeler:
         # TODO: llm_model might need to be rolled up into llm_params in the future
         llm_provider = config.get_provider()
         llm_model = config.get_model_name()
         llm_params = config.get("model_params", {})
-        llm_cls = PROVIDER_TO_LLM[llm_provider]
+        llm_cls = LLMFactory.PROVIDER_TO_LLM[llm_provider]
         llm_params = LLMFactory._resolve_params(
-            PROVIDER_TO_DEFAULT_PARAMS[llm_provider], llm_params
+            LLMFactory.PROVIDER_TO_DEFAULT_PARAMS[llm_provider], llm_params
         )
-        if llm_provider == LLMProvider.openai:
-            return llm_cls(model_name=llm_model, **llm_params)
+        if llm_provider in [LLMProvider.openai, LLMProvider.openai_chat]:
+            base_llm = llm_cls(model_name=llm_model, **llm_params)
         else:
-            return llm_cls(model=llm_model, **llm_params)
-
+            base_llm = llm_cls(model=llm_model, **llm_params)
+        return LLMLabeler(config, base_llm)
     

--- a/refuel_oracle/utils.py
+++ b/refuel_oracle/utils.py
@@ -8,6 +8,8 @@ PROVIDER_TO_COST_PER_TOKEN = {
     LLMProvider.openai: {
         'text-davinci-003': 0.02/1000,
         'text-curie-001': 0.002/1000,
+    },
+    LLMProvider.openai_chat: {
         'gpt-3.5-turbo': 0.002/1000
     }
 }


### PR DESCRIPTION
```
In [1]: from refuel_oracle.oracle import Oracle

In [2]: o = Oracle('examples/config_chatgpt.json', debug=True)

In [3]: o.plan('examples/ag_news_filtered_labels_sampled.csv', input_column='description')
Total Estimated Cost: 2.073578
Number of examples to label: 2997
Average cost per example: 0.0006918845512178845


In [5]: o.llm.base_llm
Out[5]: ChatOpenAI(verbose=False, callback_manager=<langchain.callbacks.shared.SharedCallbackManager object at 0x11c085820>, client=<class 'openai.api_resources.chat_completion.ChatCompletion'>, model_name='gpt-3.5-turbo', model_kwargs={'temperature': 0.0}, openai_api_key=None, request_timeout=60, max_retries=6, streaming=False, n=1, max_tokens=30)

In [6]: o.annotate('examples/ag_news_filtered_labels_sampled.csv', input_column='description', ground_truth_column='label', max_items=10)

Metric: support: 10
Metric: completion_rate: 1.0
Metric: accuracy: 0.9
```

