### PR TITLE
Example Selector Fix: Initialize the example selector before referring

### DIFF
--- a/refuel_oracle/oracle.py
+++ b/refuel_oracle/oracle.py
@@ -19,6 +19,7 @@ class Oracle:
         self.config = Config.from_json(config)
         self.llm = LLMFactory.from_config(self.config)
         self.task = TaskFactory.from_config(self.config)
+        self.example_selector = None
         if "example_selector" in self.config.keys():
             self.example_selector = ExampleSelector(self.config)
 


### PR DESCRIPTION
Earlier getting following error:
`File /opt/homebrew/Caskroom/miniforge/base/envs/cv/lib/python3.8/site-packages/refuel_oracle-0.0.0-py3.8.egg/refuel_oracle/oracle.py:79, in Oracle.annotate(self, dataset, max_items, output_name)
     76 final_prompts = []
     77 for i, input_i in enumerate(chunk):
     78     # Fetch few-shot seed examples
---> 79     if self.example_selector:
     80         examples = self.example_selector.get_examples(input_i)
     81     else:

AttributeError: 'Oracle' object has no attribute 'example_selector'`
