### PR TITLE
Remove the seed examples prompt in cases where no seed examples are provided.

### DIFF
--- a/refuel_oracle/tasks/classification.py
+++ b/refuel_oracle/tasks/classification.py
@@ -16,7 +16,7 @@ class ClassificationTask(BaseTask):
     DEFAULT_TASK_PROMPT = "Your job is to correctly label the provided input example into one of the following {num_labels} categories.\nCategories:\n{labels_list}\n"
     JSON_OUTPUT_FORMAT_PROMPT = 'You will return the answer in JSON format with two keys: {"answered": "can you answer this question. say yes or no", "label": "the correct label"}'
     CSV_OUTPUT_FORMAT_PROMPT = 'You will return the answer in CSV format with two elements: "can you answer this question. say Yes or No", "the correct label"'
-    SEED_EXAMPLES_PROMPT = 'Some examples with their output answers are provided below:'
+    SEED_EXAMPLES_PROMPT = "Some examples with their output answers are provided below:"
     PROMPT_TEMPLATE = "{prefix_prompt}\n{task_prompt}\n\n{output_prompt}\n\n{seed_examples_prompt}\n{seed_examples}\nNow I want you to label the following example: {current_example}"
     PROMPT_TEMPLATE_VARIABLES = [
         "prefix_prompt",

--- a/refuel_oracle/tasks/entity_recognition.py
+++ b/refuel_oracle/tasks/entity_recognition.py
@@ -14,7 +14,7 @@ from refuel_oracle.tasks import BaseTask
 class EntityRecognitionTask(BaseTask):
     DEFAULT_TASK_PROMPT = "Your job is to extract named entities mentioned in text, and classify them into one of the following {num_labels} categories.\nCategories:\n{labels_list}\n "
     DEFAULT_OUTPUT_FORMAT_PROMPT = 'You will return the answer in JSON format with two keys: {"answered": can you answer this question. say YES or NO, "entities": a JSON list of extracted entities from text}.'
-    SEED_EXAMPLES_PROMPT = 'Some examples with their output answers are provided below:'
+    SEED_EXAMPLES_PROMPT = "Some examples with their output answers are provided below:"
     PROMPT_TEMPLATE = "{prefix_prompt}\n{task_prompt}\n{output_prompt}\n\n{seed_examples_prompt}\n{seed_examples}\nBegin:{current_example}"
     PROMPT_TEMPLATE_VARIABLES = [
         "prefix_prompt",


### PR DESCRIPTION
make the seed_examples prompt a variable so that it can be omit in the case where no examples are provided

Related to this issue:
https://github.com/refuel-ai/refuel-oracle/issues/54