### PR TITLE
Hotfix: Fix data id update and termination before any labeling starts

### DIFF
--- a/refuel_oracle/data_models/task_run.py
+++ b/refuel_oracle/data_models/task_run.py
@@ -37,7 +37,8 @@ class TaskRunModel(Base):
         logger.debug(f"creating new task: {task_run}")
         db_object = cls(**task_run.dict())
         db.add(db_object)
-        db_object = db.query(cls).order_by(cls.id.desc()).first()
+        db.flush()
+        db.refresh(db_object)
         logger.debug(f"created new task: {db_object}")
         return db_object
 

--- a/refuel_oracle/database.py
+++ b/refuel_oracle/database.py
@@ -2,7 +2,7 @@ from refuel_oracle.data_models import Base
 from sqlalchemy import create_engine, MetaData
 from sqlalchemy.orm import sessionmaker
 from loguru import logger
-from typing import Tuple
+from typing import Optional
 from refuel_oracle.data_models import DatasetModel, TaskModel, TaskRunModel
 from refuel_oracle.dataset_config import DatasetConfig
 from refuel_oracle.schema import Dataset, Task, TaskRun, TaskStatus
@@ -22,7 +22,11 @@ class Database:
         self.session = sessionmaker(bind=self.engine, autocommit=True)()
 
     def initialize_dataset(
-        self, input_file: str, dataset_config: DatasetConfig, start_index, max_items
+        self,
+        input_file: str,
+        dataset_config: DatasetConfig,
+        start_index: int,
+        max_items: Optional[int],
     ):
         # TODO: Check if this works for max_items = None
         dataset_id = Dataset.create_id(
@@ -36,7 +40,7 @@ class Database:
             id=dataset_id,
             input_file=input_file,
             start_index=start_index,
-            end_index=start_index + max_items,
+            end_index=start_index + max_items if max_items else -1,
         )
         return Dataset.from_orm(DatasetModel.create(self.session, dataset))
 

--- a/refuel_oracle/oracle.py
+++ b/refuel_oracle/oracle.py
@@ -90,9 +90,9 @@ class Oracle:
         self,
         dataset: Union[str, pd.DataFrame],
         dataset_config: Union[str, Dict],
-        max_items: int = None,
-        output_name: str = None,
-        start_index: int = 0,
+        max_items: Optional[int] = None,
+        output_name: Optional[str] = None,
+        start_index: Optional[int] = 0,
     ) -> None:
         """Labels data in a given dataset. Output written to new CSV file.
 
@@ -349,15 +349,16 @@ class Oracle:
             self.db.session, task_run.id
         )
         llm_labels = [LLMAnnotation(**a.llm_annotation) for a in db_result]
-        if gt_labels:
+        if gt_labels and len(llm_labels) > 0:
             print("Evaluating the existing task...")
             gt_labels = gt_labels[: len(llm_labels)]
             eval_result = self.task.eval(llm_labels, gt_labels)
             for m in eval_result:
                 print(f"Metric: {m.name}: {m.value}")
         print(f"{len(llm_labels)} examples have been labeled so far.")
-        print(f"Last annotated example - Prompt: {llm_labels[-1].prompt}")
-        print(f"Annotation: {llm_labels[-1].label}")
+        if len(llm_labels) > 0:
+            print(f"Last annotated example - Prompt: {llm_labels[-1].prompt}")
+            print(f"Annotation: {llm_labels[-1].label}")
         user_input = input("Do you want to resume it? (y/n)")
         if user_input.lower() in ["y", "yes"]:
             print("Resuming the task...")

--- a/refuel_oracle/schema.py
+++ b/refuel_oracle/schema.py
@@ -66,6 +66,8 @@ class Dataset(BaseModel):
 class TaskType(str, Enum):
     CLASSIFICATION = "classification"
     ENTITY_RECOGNITION = "entity_recognition"
+    MULTI_CHOICE_QUESTION_ANSWERING = "multi_choice_question_answering"
+    ENTITY_MATCHING = "entity_matching"
 
 
 class Task(BaseModel):


### PR DESCRIPTION
The id was not populated by the orm on a task update. Force orm to update the object.
Fix the case when a paused task does not have any llm annotations. 0 annotations were failing metric calculations