### PR TITLE
make model_params a base model class attribute as it is used for cache retrieval

### DIFF
--- a/src/autolabel/models/base.py
+++ b/src/autolabel/models/base.py
@@ -14,6 +14,7 @@ class BaseModel(ABC):
     def __init__(self, config: ModelConfig, cache: BaseCache) -> None:
         self.config = config
         self.cache = cache
+        self.model_params = config.get_model_params()
         # Specific classes that implement this interface should run initialization steps here
         # E.g. initializing the LLM model with required parameters from ModelConfig
 


### PR DESCRIPTION
currently RefuelLLM does not have this attribute but accessed in the base model class