### PR TITLE
Making the "dataset" key optional in the config

### DIFF
--- a/src/autolabel/configs/config.py
+++ b/src/autolabel/configs/config.py
@@ -42,7 +42,7 @@ class AutolabelConfig(BaseConfig):
 
     @cached_property
     def _dataset_config(self) -> Dict:
-        return self.config[self.DATASET_CONFIG_KEY]
+        return self.config.get(self.DATASET_CONFIG_KEY, {})
 
     @cached_property
     def _model_config(self) -> Dict:


### PR DESCRIPTION
With the following config:

```python
config = {
   "task_name": "MovieSentimentReview",
   "task_type": "classification",
   "model": {
      "provider""openai",
      "name": "gpt-3.5-turbo"
   },
   "prompt": {
      "task_guidelines": "You are an expert at analyzing the sentiment of moview reviews. Your job is to classify the provided movie review as positive or negative.",
      "labels": [
         "positive",
         "negative"
      ],
      "example_template": "Input: {text}\\nOutput:"
   }
}
```

Before:
```
In [18]: agent.plan('docs/assets/movie_reviews.csv')
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Input In [18], in <cell line: 1>()
----> 1 agent.plan('docs/assets/movie_reviews.csv')

File ~/.pyenv/versions/3.8.13/envs/refuel-main/lib/python3.8/site-packages/autolabel/labeler.py:327, in LabelingAgent.plan(self, dataset, max_items, start_index)
    320 """Calculates and prints the cost of calling autolabel.run() on a given dataset
    321
    322 Args:
    323     dataset: path to a CSV dataset
    324 """
    326 if isinstance(dataset, str):
--> 327     _, inputs, _ = self._read_csv(dataset, self.config, max_items, start_index)
    328 elif isinstance(dataset, pd.DataFrame):
    329     _, inputs, _ = self._read_dataframe(
    330         dataset, self.config, max_items, start_index
    331     )

File ~/.pyenv/versions/3.8.13/envs/refuel-main/lib/python3.8/site-packages/autolabel/labeler.py:60, in LabelingAgent._read_csv(self, csv_file, config, max_items, start_index)
     52 def _read_csv(
     53     self,
     54     csv_file: str,
   (...)
     57     start_index: int = 0,
     58 ) -> Tuple[pd.DataFrame, List[Dict], List]:
     59     logger.debug(f"reading the csv from: {start_index}")
---> 60     delimiter = config.delimiter()
     61     label_column = config.label_column()
     63     dat = pd.read_csv(csv_file, sep=delimiter, dtype="str")[start_index:]

File ~/.pyenv/versions/3.8.13/envs/refuel-main/lib/python3.8/site-packages/autolabel/configs/config.py:73, in AutolabelConfig.delimiter(self)
     72 def delimiter(self) -> str:
---> 73     return self._dataset_config.get(self.DELIMITER_KEY, ",")

File ~/.pyenv/versions/3.8.13/lib/python3.8/functools.py:967, in cached_property.__get__(self, instance, owner)
    965 val = cache.get(self.attrname, _NOT_FOUND)
    966 if val is _NOT_FOUND:
--> 967     val = self.func(instance)
    968     try:
    969         cache[self.attrname] = val

File ~/.pyenv/versions/3.8.13/envs/refuel-main/lib/python3.8/site-packages/autolabel/configs/config.py:45, in AutolabelConfig._dataset_config(self)
     43 @cached_property
     44 def _dataset_config(self) -> Dict:
---> 45     return self.config[self.DATASET_CONFIG_KEY]

KeyError: 'dataset'
```

After:
```
In [4]: agent.plan('docs/assets/movie_reviews.csv')
Computing embeddings... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100/100 0:00:00 0:00:00
┌──────────────────────────┬─────────┐
│ Total Estimated Cost     │ $0.538  │
│ Number of Examples       │ 200     │
│ Average cost per example │ 0.00269 │
└──────────────────────────┴─────────┘
───────────────────────────────────────────── Prompt Example ─────────────────────────────────────────────
You are an expert at analyzing the sentiment of moview reviews. Your job is to classify the provided movie review as positive or negative.

You will return the answer with just one element: "the correct label"

Now I want you to label the following example:
Input: I was very excited about seeing this film, anticipating a visual excursus on the relation of artistic beauty and nature, containing the kinds of wisdom the likes of "Rivers and Tides." However, that's not what I received. Instead, I get a fairly uninspired film about how human industry is bad for nature. Which is clearly a quite unorthodox claim.<br /><br />The photographer seems conflicted about the aesthetic qualities of his images and the supposed "ethical" duty he has to the workers occasionally peopling the images, along the periphery. And frankly, the images were not generally that impressive. And according to this "artist," scale is the basis for what makes something beautiful.<br /><br />In all respects, a stupid film. For people who'd like to feel better about their environmental consciousness ... but not for any one who would like to think about the complexities of the issues surrounding it.\nOutput:
──────────────────────────────────────────────────────────────────────────────────────────────────────────
```