### PR TITLE
fixed confusing error when missing openai api key

### DIFF
--- a/src/autolabel/models/__init__.py
+++ b/src/autolabel/models/__init__.py
@@ -25,13 +25,13 @@ MODEL_PROVIDER_TO_IMPLEMENTATION: Dict[ModelProvider, BaseModel] = {
 class ModelFactory:
     @staticmethod
     def from_config(config: AutolabelConfig, cache: BaseCache = None) -> BaseModel:
+        model_provider = ModelProvider(config.provider())
         try:
-            model_provider = ModelProvider(config.provider())
             model_cls = MODEL_PROVIDER_TO_IMPLEMENTATION[model_provider]
-            return model_cls(config, cache)
         except ValueError as e:
             logger.error(
                 f"{config.provider()} is not in the list of supported providers: \
                 {MODEL_PROVIDER_TO_IMPLEMENTATION.keys()}"
             )
             return None
+        return model_cls(config, cache)


### PR DESCRIPTION
#202 

Now, when the `OPENAI_API_KEY` environmental variable is missing, it will print the following error instead.

```
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Cell In[24], line 1
----> 1 l = LabelingAgent(config=config, cache=False)

File [~/.pyenv/versions/3.8.16/envs/refuel/lib/python3.8/site-packages/autolabel/labeler.py:52](https://file+.vscode-resource.vscode-cdn.net/Users/workrefuel/Documents/Documents%20-%20Ty%27s%20MBP/random-tests/~/.pyenv/versions/3.8.16/envs/refuel/lib/python3.8/site-packages/autolabel/labeler.py:52), in LabelingAgent.__init__(self, config, log_level, cache)
     50 self.config = AutolabelConfig(config)
     51 self.task = TaskFactory.from_config(self.config)
---> 52 self.llm: BaseModel = ModelFactory.from_config(self.config, cache=self.cache)
     53 self.confidence = ConfidenceCalculator(
     54     score_type="logprob_average", llm=self.llm
     55 )

File [~/.pyenv/versions/3.8.16/envs/refuel/lib/python3.8/site-packages/autolabel/models/__init__.py:37](https://file+.vscode-resource.vscode-cdn.net/Users/workrefuel/Documents/Documents%20-%20Ty%27s%20MBP/random-tests/~/.pyenv/versions/3.8.16/envs/refuel/lib/python3.8/site-packages/autolabel/models/__init__.py:37), in ModelFactory.from_config(config, cache)
     32     logger.error(
     33         f"{config.provider()} is not in the list of supported providers: \
     34         {MODEL_PROVIDER_TO_IMPLEMENTATION.keys()}"
     35     )
     36     return None
---> 37 return model_cls(config, cache)

File [~/.pyenv/versions/3.8.16/envs/refuel/lib/python3.8/site-packages/autolabel/models/openai.py:60](https://file+.vscode-resource.vscode-cdn.net/Users/workrefuel/Documents/Documents%20-%20Ty%27s%20MBP/random-tests/~/.pyenv/versions/3.8.16/envs/refuel/lib/python3.8/site-packages/autolabel/models/openai.py:60), in OpenAILLM.__init__(self, config, cache)
     58 if self._engine == "chat":
     59     self.model_params = {**self.DEFAULT_PARAMS_CHAT_ENGINE, **model_params}
---> 60     self.llm = ChatOpenAI(model_name=self.model_name, **self.model_params)
     61 else:
     62     self.model_params = {
     63         **self.DEFAULT_PARAMS_COMPLETION_ENGINE,
     64         **model_params,
     65     }

File [~/.pyenv/versions/3.8.16/envs/refuel/lib/python3.8/site-packages/pydantic/main.py:341](https://file+.vscode-resource.vscode-cdn.net/Users/workrefuel/Documents/Documents%20-%20Ty%27s%20MBP/random-tests/~/.pyenv/versions/3.8.16/envs/refuel/lib/python3.8/site-packages/pydantic/main.py:341), in pydantic.main.BaseModel.__init__()

ValidationError: 1 validation error for ChatOpenAI
__root__
  Did not find openai_api_key, please add an environment variable `OPENAI_API_KEY` which contains it, or pass  `openai_api_key` as a named parameter. (type=value_error)
```