### PR TITLE
Fix GH action to deploy website if MkDocs.yml is edited

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - "docs/**"
+      - "mkdocs.yml"
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
Fix issue in which website deployment does not get triggered if mkdocs.yml is edited, because it is outside of the docs directory.