### PR TITLE
removed top_p and top_k from PaLM default params

### DIFF
--- a/src/autolabel/models/palm.py
+++ b/src/autolabel/models/palm.py
@@ -15,11 +15,7 @@ class PaLMLLM(BaseModel):
     NUM_TRIES = 5
 
     DEFAULT_MODEL = "text-bison@001"
-    DEFAULT_PARAMS = {
-        "temperature": 0,
-        "top_p": 0.8,
-        "top_k": 40,
-    }
+    DEFAULT_PARAMS = {"temperature": 0}
 
     # Reference: https://cloud.google.com/vertex-ai/pricing
     COST_PER_CHARACTER = {


### PR DESCRIPTION
Since setting temperature to 0 nullifies these parameters as outlined [here](https://cloud.google.com/vertex-ai/docs/generative-ai/start/quickstarts/api-quickstart), there is no need to keep them in the default parameters.