### PR TITLE
put links next to section headers in docs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,3 +91,5 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
+  - toc:
+      permalink: true


### PR DESCRIPTION
This setting in `mkdocs.yml` adds links that you can click/share next to each section header in the docs site.
```
markdown_extensions:
    - toc:
        permalink: true
```