### PR TITLE
Adding single quotes around pip install in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ cd autolabel
 ```
 3. Install the library from source (preferably in a virtual environment): 
 ```bash
-pip install .[dev]
+pip install '.[dev]'
 ```
 4. Install [pre-commit](https://pre-commit.com/): 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ cd autolabel
 ```bash
 pip install '.[dev]'
 ```
-4. Install [pre-commit](https://pre-commit.com/): 
+4. Install [pre-commit](https://pre-commit.com/) and then run: 
 ```bash
 pre-commit install
 ```


### PR DESCRIPTION
Before:

```
% pip install .[dev]
zsh: no matches found: .[dev]
```

After:
```
pip install '.[dev]'
Processing /private/tmp/autolabel
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting loguru>=0.5.0
  Using cached loguru-0.7.0-py3-none-any.whl (59 kB)
Collecting rich>=13.3.5
  Using cached rich-13.4.2-py3-none-any.whl (239 kB)
Collecting scipy>=1.10.1
...
```