### PR TITLE
Check if the LLM label is in the labels list

### DIFF
--- a/src/autolabel/configs/config.py
+++ b/src/autolabel/configs/config.py
@@ -101,7 +101,7 @@ class AutolabelConfig(BaseConfig):
     def task_guidelines(self) -> str:
         return self._prompt_config.get(self.TASK_GUIDELINE_KEY, "")
 
-    def labels_list(self) -> str:
+    def labels_list(self) -> List[str]:
         """Returns a list of valid labels"""
         return self._prompt_config.get(self.VALID_LABELS_KEY, [])
 

--- a/src/autolabel/tasks/base.py
+++ b/src/autolabel/tasks/base.py
@@ -91,6 +91,7 @@ class BaseTask(ABC):
                 TaskType.CLASSIFICATION,
                 TaskType.ENTITY_MATCHING,
             ]:
+                logger.warning(f"LLM response is not in the labels list")
                 successfully_labeled = llm_label in self.config.labels_list()
             else:
                 successfully_labeled = True

--- a/src/autolabel/tasks/base.py
+++ b/src/autolabel/tasks/base.py
@@ -8,7 +8,7 @@ import json
 from langchain.prompts.prompt import PromptTemplate
 from langchain.schema import Generation
 from autolabel.configs import AutolabelConfig
-from autolabel.schema import LLMAnnotation, MetricResult, FewShotAlgorithm
+from autolabel.schema import LLMAnnotation, MetricResult, FewShotAlgorithm, TaskType
 from autolabel.utils import get_format_variables, extract_valid_json_substring
 
 logger = logging.getLogger(__name__)
@@ -86,8 +86,14 @@ class BaseTask(ABC):
             llm_label = self.NULL_LABEL_TOKEN
             logger.error(f"Error parsing LLM response: {response.text}")
         else:
-            successfully_labeled = True
             llm_label = completion_text.strip()
+            if self.config.task_type() in [
+                TaskType.CLASSIFICATION,
+                TaskType.ENTITY_MATCHING,
+            ]:
+                successfully_labeled = llm_label in self.config.labels_list()
+            else:
+                successfully_labeled = True
 
         return LLMAnnotation(
             successfully_labeled=successfully_labeled,

--- a/src/autolabel/tasks/base.py
+++ b/src/autolabel/tasks/base.py
@@ -91,8 +91,11 @@ class BaseTask(ABC):
                 TaskType.CLASSIFICATION,
                 TaskType.ENTITY_MATCHING,
             ]:
-                logger.warning(f"LLM response is not in the labels list")
-                successfully_labeled = llm_label in self.config.labels_list()
+                if llm_label in self.config.labels_list():
+                    successfully_labeled = True
+                else:
+                    logger.warning(f"LLM response is not in the labels list")
+                    successfully_labeled = False
             else:
                 successfully_labeled = True
 


### PR DESCRIPTION
If the LLM response does not correspond to a label in the labels list (only for `classification` and `entity_matching` tasks) then we will mark `successfully_labeled` as `False` for the row and print the warning as shown below.
![Screenshot 2023-06-19 at 3 35 28 PM](https://github.com/refuel-ai/autolabel/assets/25215977/f70e9a48-a8d8-4238-b1df-95d94a6d041a)
