### PR TITLE
Update get_data and add test case

### DIFF
--- a/src/autolabel/utils.py
+++ b/src/autolabel/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import os
 import json
 import logging
 from string import Formatter
@@ -250,7 +251,26 @@ def print_table(
     console.print(table)
 
 
-def get_data(dataset_name: str):
+def get_data(dataset_name: str, force: bool = False):
+    """Download Datasets
+
+    Args:
+        dataset_name (str): dataset name
+        force (bool, optional): if set to True, downloads and overwrites the local test and seed files
+            if false then downloads onlyif the files are not present locally
+    """
+
+    def download(url: str) -> None:
+        """Downloads the data given an url"""
+        file_name = os.path.basename(url)
+        if force and os.path.exists(file_name):
+            print(f"File {file_name} exists. Removing")
+            os.remove(file_name)
+
+        if not os.path.exists(file_name):
+            print(f"Downloading example dataset from {url} to {file_name}...")
+            wget.download(url)
+
     if dataset_name not in EXAMPLE_DATASETS:
         logger.error(
             f"{dataset_name} not in list of available datasets: {str(EXAMPLE_DATASETS)}. Exiting..."
@@ -258,13 +278,9 @@ def get_data(dataset_name: str):
         return
     seed_url = DATASET_URL.format(dataset=dataset_name, partition="seed")
     test_url = DATASET_URL.format(dataset=dataset_name, partition="test")
-
     try:
         if dataset_name not in NO_SEED_DATASET:
-            print('Downloading seed example dataset to "seed.csv"...')
-            wget.download(seed_url)
-            print("\n")
-        print('Downloading test dataset to "test.csv"...')
-        wget.download(test_url)
+            download(seed_url)
+        download(test_url)
     except Exception as e:
         logger.error(f"Error downloading dataset: {e}")

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,11 @@
+"""Set Dummy Environments"""
+
+import os
+
+os.environ.update(
+    {
+        "REFUEL_API_KEY": "dummy_refuel_api_key",
+        "OPENAI_API_KEY": "dummy_open_api_key",
+        "ANTHROPIC_API_KEY": "dummy_anthropic_api_key",
+    }
+)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -9,19 +9,8 @@ from rich.console import Console
 console = Console()
 
 
-def generate_tempfile_with_content(input_url: str) -> None:
-    """Generate a Temporary file with dummy content"""
-    with tempfile.NamedTemporaryFile(dir="./", delete=False) as tmp_file:
-        file_name = os.path.basename(input_url)
-        os.rename(tmp_file.name, file_name)
-        tmp_file.write(f"{input_url}".encode("utf-8"))
-        tmp_file.flush()
-
-
 def test_get_data(mocker) -> None:
     """Test Get Data"""
-    mocker.patch("wget.download", side_effect=generate_tempfile_with_content)
-
     dataset_name = "banking"
 
     def assert_text_remove(file_name_: str, text: str):
@@ -35,6 +24,16 @@ def test_get_data(mocker) -> None:
             file_content = tmp_file_read.read()
             assert file_content == text
         os.remove(file_name)
+
+    def generate_tempfile_with_content(input_url: str) -> None:
+        """Generate a Temporary file with dummy content"""
+        with tempfile.NamedTemporaryFile(dir="./", delete=False) as tmp_file:
+            file_name = os.path.basename(input_url)
+            os.rename(tmp_file.name, file_name)
+            tmp_file.write(f"{input_url}".encode("utf-8"))
+            tmp_file.flush()
+
+    mocker.patch("wget.download", side_effect=generate_tempfile_with_content)
 
     # The below case handles the case when the force argument is not provided
     # We create two dummy files and insert text to it.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -18,9 +18,10 @@ def generate_tempfile_with_content(input_url: str) -> None:
         tmp_file.flush()
 
 
-@mock.patch("wget.download", side_effect=generate_tempfile_with_content)
-def test_get_data(mock_download) -> None:
+def test_get_data(mocker) -> None:
     """Test Get Data"""
+    mocker.patch("wget.download", side_effect=generate_tempfile_with_content)
+
     dataset_name = "banking"
 
     def assert_text_remove(file_name_: str, text: str):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,7 +2,6 @@
 
 import tempfile
 import os
-from unittest import mock
 from autolabel import utils
 from rich.console import Console
 


### PR DESCRIPTION
Fix bug report https://github.com/refuel-ai/autolabel/issues/349

This PR adds a test case for two possible scenarios
1. when `force` = True, files are overwritten
2. when `force` = False, if files are present, download doesn't take place