### PR TITLE
added support for hugging face datasets

### DIFF
--- a/src/autolabel/dataset_loader.py
+++ b/src/autolabel/dataset_loader.py
@@ -218,11 +218,11 @@ class DatasetLoader:
             max_items (int, optional): max number of items to read. Defaults to None.
             start_index (int, optional): start index to read from. Defaults to 0.
         """
-        self.dat = pd.DataFrame(
-            dataset[
-                start_index : max_items if max_items and max_items > 0 else len(dataset)
-            ]
-        )
+        dataset.set_format("pandas")
+        self.dat = dataset[
+            start_index : max_items if max_items and max_items > 0 else len(dataset)
+        ]
+
         self.inputs = self.dat.to_dict(orient="records")
         self.gt_labels = (
             None

--- a/src/autolabel/dataset_loader.py
+++ b/src/autolabel/dataset_loader.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Tuple, Union
 import logging
 import pandas as pd
 from sqlalchemy.sql.selectable import Selectable
+from datasets import Dataset
 
 
 from autolabel.configs import AutolabelConfig
@@ -36,6 +37,8 @@ class DatasetLoader:
 
         if isinstance(dataset, str):
             self._read_file(dataset, config, max_items, start_index)
+        elif isinstance(dataset, Dataset):
+            self._read_hf_dataset(dataset, config, max_items, start_index)
         elif isinstance(dataset, pd.DataFrame):
             self._read_dataframe(dataset, config, start_index, max_items)
 
@@ -199,3 +202,32 @@ class DatasetLoader:
             )
         else:
             raise ValueError(f"Unsupported file format: {file}")
+
+    def _read_hf_dataset(
+        self,
+        dataset: Dataset,
+        config: AutolabelConfig,
+        max_items: int = None,
+        start_index: int = 0,
+    ) -> None:
+        """Read the huggingface dataset and sets dat, inputs and gt_labels
+
+        Args:
+            dataset (Dataset): dataset object to read from
+            config (AutolabelConfig): config object
+            max_items (int, optional): max number of items to read. Defaults to None.
+            start_index (int, optional): start index to read from. Defaults to 0.
+        """
+        self.dat = pd.DataFrame(
+            dataset[
+                start_index : max_items if max_items and max_items > 0 else len(dataset)
+            ]
+        )
+        self.inputs = self.dat.to_dict(orient="records")
+        self.gt_labels = (
+            None
+            if not config.label_column()
+            or not len(self.inputs)
+            or config.label_column() not in self.inputs[0]
+            else self.dat[config.label_column()].tolist()
+        )

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -66,17 +66,21 @@ class LabelingAgent:
             output_name: custom name of output CSV file
             start_index: skips annotating [0, start_index)
         """
+        dataset_loader = DatasetLoader(dataset, self.config, max_items, start_index)
 
         self.db.initialize()
         self.dataset = self.db.initialize_dataset(
-            dataset, self.config, start_index, max_items
+            dataset_loader.dat, self.config, start_index, max_items
         )
         self.task_object = self.db.initialize_task(self.config)
-        csv_file_name = (
-            output_name if output_name else f"{dataset.replace('.csv','')}_labeled.csv"
-        )
-
-        dataset_loader = DatasetLoader(dataset, self.config, max_items, start_index)
+        if isinstance(dataset, str):
+            csv_file_name = (
+                output_name
+                if output_name
+                else f"{dataset.replace('.csv','')}_labeled.csv"
+            )
+        else:
+            csv_file_name = "labeled.csv"
 
         # Initialize task run and check if it already exists
         self.task_run = self.db.get_task_run(self.task_object.id, self.dataset.id)

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -80,7 +80,7 @@ class LabelingAgent:
                 else f"{dataset.replace('.csv','')}_labeled.csv"
             )
         else:
-            csv_file_name = "labeled.csv"
+            csv_file_name = f"{self.config.task_name()}_labeled.csv"
 
         # Initialize task run and check if it already exists
         self.task_run = self.db.get_task_run(self.task_object.id, self.dataset.id)


### PR DESCRIPTION
We can now load datasets from Huggingface as show below
```python
dataset = load_dataset("lex_glue", "ledgar")

test_dataset = dataset["test"]
test_dataset = map_label_to_string(test_dataset, "label")

test_dataset = test_dataset.rename_column("text", "example")

ledgar_path = Path("../autolabel/examples/ledgar")
with open(ledgar_path / "config_ledgar.json", "r") as f:
    config = json.load(f)
if "few_shot_examples" in config["prompt"] and isinstance(config["prompt"]["few_shot_examples"], str):
    config["prompt"]["few_shot_examples"] = str(ledgar_path / config["prompt"]["few_shot_examples"])
agent = LabelingAgent(config)

agent.plan(test_dataset, max_items=8)
agent.run(test_dataset, max_items=8)
```