### PR TITLE
Pin Langchain to a working version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,6 @@ name: Tests
 
 on:
   pull_request:
-    types: [opened, reopened]
     branches:
       - "main"
   push:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "numpy >= 1.23.0",
     "requests >= 2.27.0",
     "datasets >= 2.7.0",
-    "langchain >= 0.0.194",
+    "langchain == 0.0.210",
     "nervaluate >= 0.1.8",
     "pandas >= 1.3.0",
     "scikit-learn >= 1.0.0",


### PR DESCRIPTION
Since langchain push multiple releases a day, it can break the library. Pinning it to the last working version.