### PR TITLE
Black formatting checks to run on PR branch

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -1,10 +1,11 @@
 name: Black
-on: 
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+on:
+  pull_request:
+    branches:
+      - "main"
   push:
     branches:
-      - '**'
+      - "main"
 
 jobs:
   lint:

--- a/src/autolabel/database/engine.py
+++ b/src/autolabel/database/engine.py
@@ -9,7 +9,7 @@ DB_ENGINE = None
 # Having one global SQLite database in ~ is a poor idea, since
 # SQLite cannot handle multiple simultaneous writes (if you have
 # several different labeling jobs going on).
-#DB_PATH = join(expanduser("~"), ".autolabel.db")
+# DB_PATH = join(expanduser("~"), ".autolabel.db")
 
 DB_PATH = ".autolabel.db"
 


### PR DESCRIPTION
Previously we were running the formatting checks on PR but on the base commit on the target branch. Modified it to run formatting checks on the commit on the PR branch.