### PR TITLE
added cohere support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ huggingface = [
 google = [
     "google-cloud-aiplatform>=1.25.0"
 ]
+cohere = [
+    "cohere>=4.11.2"
+]
 all = [
     "black",
     "bumpver",
@@ -83,6 +86,7 @@ all = [
     "anthropic == 0.2.6",
     "transformers >= 4.25.0",
     "google-cloud-aiplatform>=1.25.0",
+    "cohere>=4.11.2",
     "sentence_transformers"
 ]
 

--- a/src/autolabel/models/__init__.py
+++ b/src/autolabel/models/__init__.py
@@ -43,6 +43,10 @@ class ModelFactory:
                 from .palm import PaLMLLM
 
                 model_cls = PaLMLLM
+            elif model_provider == ModelProvider.COHERE:
+                from .cohere import CohereLLM
+
+                model_cls = CohereLLM
             else:
                 raise ValueError
         except ValueError as e:

--- a/src/autolabel/models/cohere.py
+++ b/src/autolabel/models/cohere.py
@@ -1,0 +1,58 @@
+from functools import cached_property
+from typing import List, Optional
+import os
+
+import cohere
+from langchain.llms import Cohere
+from langchain.schema import LLMResult
+from langchain import PromptTemplate, LLMChain
+
+from autolabel.models import BaseModel
+from autolabel.configs import AutolabelConfig
+from autolabel.cache import BaseCache
+
+
+class CohereLLM(BaseModel):
+    # Default parameters for OpenAILLM
+    DEFAULT_MODEL = "command"
+    DEFAULT_MODEL_PARAMS = {
+        "max_tokens": 1000,
+        "temperature": 0.0,
+    }
+
+    # Reference: https://cohere.com/pricing
+    COST_PER_TOKEN = 15 / 1_000_000
+
+    def __init__(self, config: AutolabelConfig, cache: BaseCache = None) -> None:
+        super().__init__(config, cache)
+        # populate model name
+        self.model_name = config.model_name() or self.DEFAULT_MODEL
+
+        # populate model params and initialize the LLM
+        model_params = config.model_params()
+        self.model_params = {
+            **self.DEFAULT_MODEL_PARAMS,
+            **model_params,
+        }
+        self.llm = Cohere(model=self.model_name, **self.model_params)
+        self.co = cohere.Client(api_key=os.environ["COHERE_API_KEY"])
+
+    def _label(self, prompts: List[str]) -> LLMResult:
+        try:
+            return self.llm.generate(prompts)
+        except Exception as e:
+            print(f"Error generating from LLM: {e}, returning empty result")
+            generations = [[Generation(text="")] for _ in prompts]
+            return LLMResult(generations=generations)
+
+    def get_cost(self, prompt: str, label: Optional[str] = "") -> float:
+        num_prompt_toks = len(self.co.tokenize(prompt).tokens)
+        if label:
+            num_label_toks = len(self.co.tokenize(label).tokens)
+        else:
+            num_label_toks = self.model_params["max_tokens"]
+
+        return self.COST_PER_TOKEN * (num_prompt_toks + num_label_toks)
+
+    def returns_token_probs(self) -> bool:
+        return False

--- a/src/autolabel/models/cohere.py
+++ b/src/autolabel/models/cohere.py
@@ -16,7 +16,7 @@ class CohereLLM(BaseModel):
     # Default parameters for OpenAILLM
     DEFAULT_MODEL = "command"
     DEFAULT_MODEL_PARAMS = {
-        "max_tokens": 1000,
+        "max_tokens": 512,
         "temperature": 0.0,
     }
 

--- a/src/autolabel/schema.py
+++ b/src/autolabel/schema.py
@@ -18,6 +18,7 @@ class ModelProvider(str, Enum):
     HUGGINGFACE_PIPELINE = "huggingface_pipeline"
     REFUEL = "refuel"
     GOOGLE = "google"
+    COHERE = "cohere"
 
 
 class TaskType(str, Enum):


### PR DESCRIPTION
Added [Cohere](https://cohere.com/) support that currently only supports the generation models, defaulting to `command`. To use it, set `config["model"]["provider"]` to `cohere`.