### PR TITLE
Support example selection using label diversity by random and by semantic similarity

### DIFF
--- a/src/autolabel/few_shot/__init__.py
+++ b/src/autolabel/few_shot/__init__.py
@@ -97,6 +97,7 @@ class ExampleSelectorFactory:
             FewShotAlgorithm.LABEL_DIVERSITY_SIMILARITY,
         ]:
             params["label_key"] = config.label_column()
+            params["num_labels"] = len(config.labels_list())
 
         example_cls = ALGORITHM_TO_IMPLEMENTATION[algorithm]
         return example_cls.from_examples(**params)

--- a/src/autolabel/few_shot/__init__.py
+++ b/src/autolabel/few_shot/__init__.py
@@ -17,12 +17,18 @@ from langchain.prompts.example_selector import (
 from langchain.prompts.example_selector.base import BaseExampleSelector
 
 from .fixed_example_selector import FixedExampleSelector
+from .label_diversity_example_selector import (
+    LabelDiversityRandomExampleSelector,
+    LabelDiversitySimilarityExampleSelector,
+)
 from .vector_store import VectorStoreWrapper
 
 ALGORITHM_TO_IMPLEMENTATION: Dict[FewShotAlgorithm, BaseExampleSelector] = {
     FewShotAlgorithm.FIXED: FixedExampleSelector,
     FewShotAlgorithm.SEMANTIC_SIMILARITY: SemanticSimilarityExampleSelector,
     FewShotAlgorithm.MAX_MARGINAL_RELEVANCE: MaxMarginalRelevanceExampleSelector,
+    FewShotAlgorithm.LABEL_DIVERSITY_RANDOM: LabelDiversityRandomExampleSelector,
+    FewShotAlgorithm.LABEL_DIVERSITY_SIMILARITY: LabelDiversitySimilarityExampleSelector,
 }
 
 DEFAULT_EMBEDDING_PROVIDER = OpenAIEmbeddings
@@ -62,6 +68,7 @@ class ExampleSelectorFactory:
         if algorithm in [
             FewShotAlgorithm.SEMANTIC_SIMILARITY,
             FewShotAlgorithm.MAX_MARGINAL_RELEVANCE,
+            FewShotAlgorithm.LABEL_DIVERSITY_SIMILARITY,
         ]:
             model_provider = config.embedding_provider()
             embedding_model_class = PROVIDER_TO_MODEL.get(
@@ -85,6 +92,11 @@ class ExampleSelectorFactory:
                 ExampleSelectorFactory.MAX_CANDIDATE_EXAMPLES,
                 ExampleSelectorFactory.CANDIDATE_EXAMPLES_FACTOR * params["k"],
             )
+        if algorithm in [
+            FewShotAlgorithm.LABEL_DIVERSITY_RANDOM,
+            FewShotAlgorithm.LABEL_DIVERSITY_SIMILARITY,
+        ]:
+            params["label_key"] = config.label_column()
 
         example_cls = ALGORITHM_TO_IMPLEMENTATION[algorithm]
         return example_cls.from_examples(**params)

--- a/src/autolabel/few_shot/label_diversity_example_selector.py
+++ b/src/autolabel/few_shot/label_diversity_example_selector.py
@@ -54,6 +54,7 @@ class LabelDiversityRandomExampleSelector(BaseExampleSelector, BaseModel):
         cls,
         examples: List[dict],
         label_key: str,
+        num_labels: int,
         k: int = 4,
     ) -> LabelDiversityRandomExampleSelector:
         """Create label diversity example selector using example list and embeddings.
@@ -66,7 +67,7 @@ class LabelDiversityRandomExampleSelector(BaseExampleSelector, BaseModel):
         Returns:
             The ExampleSelector instantiated
         """
-        return cls(k=k, examples=examples, label_key=label_key)
+        return cls(k=k, examples=examples, label_key=label_key, num_labels=num_labels)
 
 
 class LabelDiversitySimilarityExampleSelector(BaseExampleSelector, BaseModel):
@@ -123,6 +124,7 @@ class LabelDiversitySimilarityExampleSelector(BaseExampleSelector, BaseModel):
         label_key: str,
         embeddings: Embeddings,
         vectorstore_cls: Type[VectorStore],
+        num_labels: int,
         k: int = 4,
         input_keys: Optional[List[str]] = None,
         **vectorstore_cls_kwargs: Any,
@@ -157,4 +159,5 @@ class LabelDiversitySimilarityExampleSelector(BaseExampleSelector, BaseModel):
             k=k,
             input_keys=input_keys,
             label_key=label_key,
+            num_labels=num_labels,
         )

--- a/src/autolabel/few_shot/label_diversity_example_selector.py
+++ b/src/autolabel/few_shot/label_diversity_example_selector.py
@@ -96,8 +96,8 @@ class LabelDiversitySimilarityExampleSelector(BaseExampleSelector, BaseModel):
         return ids[0]
 
     def select_examples(self, input_variables: Dict[str, str]) -> List[dict]:
-        """Select which examples to use based on semantic similarity."""
-        # Get the docs with the highest similarity.
+        """Select which examples to use based on label diversity and semantic similarity."""
+        # Get the docs with the highest similarity for each label.
         if self.input_keys:
             input_variables = {key: input_variables[key] for key in self.input_keys}
         query = " ".join(sorted_values(input_variables))
@@ -120,17 +120,16 @@ class LabelDiversitySimilarityExampleSelector(BaseExampleSelector, BaseModel):
         input_keys: Optional[List[str]] = None,
         **vectorstore_cls_kwargs: Any,
     ) -> LabelDiversitySimilarityExampleSelector:
-        """Create k-shot example selector using example list and embeddings.
-
-        Reshuffles examples dynamically based on query similarity.
+        """Create k-shot example selector using example list and embeddings, taking label diversity and semantic similarity into account.
 
         Args:
             examples: List of examples to use in the prompt.
-            embeddings: An iniialized embedding API interface, e.g. OpenAIEmbeddings().
+            embeddings: An initialized embedding API interface, e.g. OpenAIEmbeddings().
             vectorstore_cls: A vector store DB interface class, e.g. FAISS.
             k: Number of examples to select
             input_keys: If provided, the search is based on the input variables
                 instead of all variables.
+            label_key: The column name corresponding to the label
             vectorstore_cls_kwargs: optional kwargs containing url for vector store
 
         Returns:

--- a/src/autolabel/few_shot/label_diversity_example_selector.py
+++ b/src/autolabel/few_shot/label_diversity_example_selector.py
@@ -1,0 +1,154 @@
+"""Example selector that selects examples based on SemanticSimilarity."""
+from __future__ import annotations
+
+from itertools import groupby
+from operator import itemgetter
+from typing import Any, Dict, List, Optional, Type
+
+from langchain.embeddings.base import Embeddings
+from langchain.prompts.example_selector.base import BaseExampleSelector
+from langchain.vectorstores.base import VectorStore
+from pydantic import BaseModel, Extra
+
+
+def sorted_values(values: Dict[str, str]) -> List[Any]:
+    """Return a list of values in dict sorted by key."""
+    return [values[val] for val in sorted(values)]
+
+
+class LabelDiversityRandomExampleSelector(BaseExampleSelector, BaseModel):
+    """Example selector that selects examples based on SemanticSimilarity."""
+
+    examples: List[dict]
+    """A list of the examples that the prompt template expects."""
+    k: int = 1
+    """Number of examples to select per label."""
+    label_key: str
+    """Name of the label column/key."""
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        extra = Extra.forbid
+        arbitrary_types_allowed = True
+
+    def add_example(self, example: Dict[str, str]) -> None:
+        self.examples.append(example)
+
+    def select_examples(self, input_variables: Dict[str, str]) -> List[dict]:
+        selected_examples = []
+        sorted_examples = sorted(self.examples, key=itemgetter(self.label_key))
+        for label, label_examples in groupby(
+            sorted_examples, key=itemgetter(self.label_key)
+        ):
+            label_examples_list = list(label_examples)
+            selected_examples.extend(label_examples_list[: self.k])
+        return selected_examples
+
+    @classmethod
+    def from_examples(
+        cls,
+        examples: List[dict],
+        label_key: str,
+        k: int = 4,
+    ) -> LabelDiversityRandomExampleSelector:
+        """Create label diversity example selector using example list and embeddings.
+
+        Args:
+            examples: List of examples to use in the prompt.
+            k: Number of examples to select per label
+            label_key: Determines which variable corresponds to the example's label
+
+        Returns:
+            The ExampleSelector instantiated
+        """
+        return cls(k=k, examples=examples, label_key=label_key)
+
+
+class LabelDiversitySimilarityExampleSelector(BaseExampleSelector, BaseModel):
+    """ExampleSelector that selects examples based on label diversity, while choosing the most similar examples for each label"""
+
+    vectorstore: VectorStore
+    """VectorStore than contains information about examples."""
+    k: int = 4
+    """Number of examples to select per label."""
+    input_keys: Optional[List[str]] = None
+    """Optional keys to filter input to. If provided, the search is based on
+    the input variables instead of all variables."""
+    label_key: str
+    """Name of the label column/key."""
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        extra = Extra.forbid
+        arbitrary_types_allowed = True
+
+    def add_example(self, example: Dict[str, str]) -> str:
+        """Add new example to vectorstore."""
+        if self.input_keys:
+            string_example = " ".join(
+                sorted_values({key: example[key] for key in self.input_keys})
+            )
+        else:
+            string_example = " ".join(sorted_values(example))
+        ids = self.vectorstore.add_texts([string_example], metadatas=[example])
+        return ids[0]
+
+    def select_examples(self, input_variables: Dict[str, str]) -> List[dict]:
+        """Select which examples to use based on semantic similarity."""
+        # Get the docs with the highest similarity.
+        if self.input_keys:
+            input_variables = {key: input_variables[key] for key in self.input_keys}
+        query = " ".join(sorted_values(input_variables))
+        example_docs = self.vectorstore.label_diversity_similarity_search(
+            query, self.label_key, k=self.k
+        )
+        # Get the examples from the metadata.
+        # This assumes that examples are stored in metadata.
+        examples = [dict(e.metadata) for e in example_docs]
+        return examples
+
+    @classmethod
+    def from_examples(
+        cls,
+        examples: List[dict],
+        label_key: str,
+        embeddings: Embeddings,
+        vectorstore_cls: Type[VectorStore],
+        k: int = 4,
+        input_keys: Optional[List[str]] = None,
+        **vectorstore_cls_kwargs: Any,
+    ) -> LabelDiversitySimilarityExampleSelector:
+        """Create k-shot example selector using example list and embeddings.
+
+        Reshuffles examples dynamically based on query similarity.
+
+        Args:
+            examples: List of examples to use in the prompt.
+            embeddings: An iniialized embedding API interface, e.g. OpenAIEmbeddings().
+            vectorstore_cls: A vector store DB interface class, e.g. FAISS.
+            k: Number of examples to select
+            input_keys: If provided, the search is based on the input variables
+                instead of all variables.
+            vectorstore_cls_kwargs: optional kwargs containing url for vector store
+
+        Returns:
+            The ExampleSelector instantiated, backed by a vector store.
+        """
+        if input_keys:
+            string_examples = [
+                " ".join(sorted_values({k: eg[k] for k in input_keys}))
+                for eg in examples
+            ]
+        else:
+            string_examples = [" ".join(sorted_values(eg)) for eg in examples]
+        vectorstore = vectorstore_cls.from_texts(
+            string_examples, embeddings, metadatas=examples, **vectorstore_cls_kwargs
+        )
+        return cls(
+            vectorstore=vectorstore,
+            k=k,
+            input_keys=input_keys,
+            label_key=label_key,
+        )

--- a/src/autolabel/few_shot/vector_store.py
+++ b/src/autolabel/few_shot/vector_store.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import copy
 import heapq
 from itertools import groupby
-from operator import itemgetter
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
 
 import numpy as np

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -1,14 +1,13 @@
+import logging
 import os
 import sys
 from typing import Dict, List, Optional, Tuple, Union
-import logging
 
 import numpy as np
 import pandas as pd
 from rich import print as pprint
 from rich.console import Console
 from rich.prompt import Confirm
-import pandas as pd
 
 from autolabel.cache import SQLAlchemyCache
 from autolabel.confidence import ConfidenceCalculator
@@ -20,7 +19,7 @@ from autolabel.few_shot import ExampleSelectorFactory
 from autolabel.models import BaseModel, ModelFactory
 from autolabel.schema import LLMAnnotation, MetricResult, TaskRun, TaskStatus
 from autolabel.tasks import TaskFactory
-from autolabel.utils import track, track_with_stats, print_table, maybe_round
+from autolabel.utils import maybe_round, print_table, track, track_with_stats
 
 console = Console()
 logger = logging.getLogger(__name__)

--- a/src/autolabel/schema.py
+++ b/src/autolabel/schema.py
@@ -1,13 +1,13 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Optional, List, Union
-import pandas as pd
+from typing import Any, Dict, List, Optional, Union
 
+import pandas as pd
+from langchain.schema import Generation
 from pydantic import BaseModel
 
 from autolabel.configs import AutolabelConfig
 from autolabel.utils import calculate_md5
-from langchain.schema import Generation
 
 
 class ModelProvider(str, Enum):
@@ -37,6 +37,8 @@ class FewShotAlgorithm(str, Enum):
     FIXED = "fixed"
     SEMANTIC_SIMILARITY = "semantic_similarity"
     MAX_MARGINAL_RELEVANCE = "max_marginal_relevance"
+    LABEL_DIVERSITY_RANDOM = "label_diversity_random"
+    LABEL_DIVERSITY_SIMILARITY = "label_diversity_similarity"
 
 
 class TaskStatus(str, Enum):


### PR DESCRIPTION
Currently, we order the examples grouped by label, but might want to randomize the order of the selected examples.