### PR TITLE
Dataset validation fix for explanation generation

### DIFF
--- a/src/autolabel/data_loaders/__init__.py
+++ b/src/autolabel/data_loaders/__init__.py
@@ -1,18 +1,18 @@
 import logging
-import pandas as pd
-from tabulate import tabulate
 from typing import Dict, Union
-from datasets import Dataset
-from autolabel.data_loaders.read_datasets import (
+
+import pandas as pd
+from autolabel.configs import AutolabelConfig
+from autolabel.data_loaders.read_datasets import (  # SqlDatasetReader,
     AutolabelDataset,
     CSVReader,
-    JsonlReader,
-    HuggingFaceDatasetReader,
-    # SqlDatasetReader,
     DataframeReader,
+    HuggingFaceDatasetReader,
+    JsonlReader,
 )
 from autolabel.data_loaders.validation import TaskDataValidation
-from autolabel.configs import AutolabelConfig
+from datasets import Dataset
+from tabulate import tabulate
 
 logger = logging.getLogger(__name__)
 

--- a/src/autolabel/data_loaders/validation.py
+++ b/src/autolabel/data_loaders/validation.py
@@ -1,14 +1,14 @@
 """Data and Schema Validation"""
 
-import re
 import json
+import re
 from functools import cached_property
-from typing import Dict, List, Union, Optional
 from json.decoder import JSONDecodeError
-from pydantic import BaseModel, create_model, ValidationError, root_validator
-from pydantic.types import StrictStr
-from autolabel.configs import AutolabelConfig
+from typing import Dict, List, Optional, Union
 
+from autolabel.configs import AutolabelConfig
+from pydantic import BaseModel, ValidationError, create_model, root_validator
+from pydantic.types import StrictStr
 
 # Regex pattern to extract expected column from onfig.example_template()
 EXPECTED_COLUMN_PATTERN = r"\{([^}]*)\}"
@@ -35,7 +35,7 @@ class NERTaskValidate(BaseModel):
                 unmatched_label = set(seed_labels.keys()) - self.labels_set
                 if len(unmatched_label) != 0:
                     raise ValueError(
-                        f"labels: '{unmatched_label}' not in promt/labels provided in config "
+                        f"labels: '{unmatched_label}' not in prompt/labels provided in config "
                     )
             except JSONDecodeError:
                 raise
@@ -66,14 +66,14 @@ class ClassificationTaskValidate(BaseModel):
                 unmatched_label = set(seed_labels) - self.labels_set
                 if len(unmatched_label) != 0:
                     raise ValueError(
-                        f"labels: '{unmatched_label}' not in promt/labels provided in config "
+                        f"labels: '{unmatched_label}' not in prompt/labels provided in config "
                     )
             except SyntaxError:
                 raise
         else:
             if value not in self.labels_set:
                 raise ValueError(
-                    f"labels: '{value}' not in promt/labels provided in config "
+                    f"labels: '{value}' not in prompt/labels provided in config "
                 )
 
 
@@ -89,7 +89,7 @@ class EMTaskValidate(BaseModel):
     def validate(self, value: str):
         if value not in self.labels_set:
             raise ValueError(
-                f"labels: '{value}' not in promt/labels provided in config "
+                f"labels: '{value}' not in prompt/labels provided in config "
             )
 
 
@@ -139,9 +139,11 @@ class TaskDataValidation:
         label_column: str = config.label_column()
         # list of valid labels provided in config "config/prompt/labels"
         labels_list: Optional[List] = config.labels_list()
-        # example template from config "config/prompt/example_template"
 
+        # example template from config "config/prompt/example_template"
         self.example_template: str = config.example_template()
+        # the explanation column as specified in config, "config/dataset/explanation_column"
+        self.explanation_column: str = config.explanation_column()
 
         self.__schema = {col: (StrictStr, ...) for col in self.expected_columns}
 
@@ -159,6 +161,8 @@ class TaskDataValidation:
         for text in self.example_template.split("\n"):
             matches = re.findall(EXPECTED_COLUMN_PATTERN, text)
             column_name_lists += matches
+        if self.explanation_column and self.explanation_column in column_name_lists:
+            column_name_lists.remove(self.explanation_column)
         return column_name_lists
 
     @property
@@ -237,9 +241,11 @@ class TaskDataValidation:
     def validate_dataset_columns(self, dataset_columns: List):
         """Validate columns
 
-        Valiate if the columns mentioned in example_template dataset are correct
-        and are contined within the columns of the dataset(seed.csv)
+        Validate if the columns mentioned in example_template dataset are correct
+        and are contained within the columns of the dataset(seed.csv)
         """
+        if self.explanation_column in dataset_columns:
+            dataset_columns.remove(self.explanation_column)
         missing_columns = set(self.expected_columns) - set(dataset_columns)
         assert (
             len(missing_columns) == 0

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -12,9 +12,9 @@ from rich.prompt import Confirm
 from autolabel.cache import SQLAlchemyCache
 from autolabel.confidence import ConfidenceCalculator
 from autolabel.configs import AutolabelConfig
+from autolabel.data_loaders import DatasetLoader
 from autolabel.data_models import AnnotationModel, TaskRunModel
 from autolabel.database import StateManager
-from autolabel.data_loaders import DatasetLoader
 from autolabel.few_shot import ExampleSelectorFactory
 from autolabel.models import BaseModel, ModelFactory
 from autolabel.schema import LLMAnnotation, MetricResult, TaskRun, TaskStatus
@@ -305,9 +305,7 @@ class LabelingAgent:
                 "REFUEL_API_KEY environment variable must be set to compute confidence scores. You can request an API key at https://refuel-ai.typeform.com/llm-access."
             )
 
-        dataset_loader = DatasetLoader(
-            dataset, self.config, max_items, start_index, validate=True
-        )
+        dataset_loader = DatasetLoader(dataset, self.config, max_items, start_index)
 
         prompt_list = []
         total_cost = 0
@@ -317,7 +315,7 @@ class LabelingAgent:
 
         # If this dataset config is a string, read the corrresponding csv file
         if isinstance(seed_examples, str):
-            seed_loader = DatasetLoader(seed_examples, self.config, validate=True)
+            seed_loader = DatasetLoader(seed_examples, self.config)
             seed_examples = seed_loader.inputs
 
         # Check explanations are present in data if explanation_column is passed in
@@ -445,7 +443,8 @@ class LabelingAgent:
         out_file = None
         if isinstance(seed_examples, str):
             out_file = seed_examples
-            _, seed_examples, _ = DatasetLoader.read_file(seed_examples, self.config)
+            seed_loader = DatasetLoader(seed_examples, self.config)
+            seed_examples = seed_loader.inputs
 
         explanation_column = self.config.explanation_column()
         if not explanation_column:


### PR DESCRIPTION
2 fixes here: 

1) read_file no longer exists in the DatasetLoader class so updated that

2) There was a subsequent set of errors due to dataset validation expecting an explanation column in the dataset (in seed.csv before explanation column was generated and in test.csv since explanation column isn't supposed to exist in the test dataset). Added a fix to not include the explanation column in all dataset validation. We do already have a separate check for the existence of the explanation column prior to example selection when appropriate here: https://github.com/refuel-ai/autolabel/blob/main/src/autolabel/labeler.py#L107