### PR TITLE
consolidate compute f1 to single function in utils

### DIFF
--- a/src/autolabel/schema.py
+++ b/src/autolabel/schema.py
@@ -56,6 +56,8 @@ class Metric(str, Enum):
     CONFUSION_MATRIX = "confusion_matrix"
     LABEL_DISTRIBUTION = "label_distribution"
     F1 = "f1"
+    F1_MACRO = "f1_macro"
+    F1_WEIGHTED = "f1_weighted"
     # Confidence metrics
     AUROC = "auroc"
     THRESHOLD = "threshold"

--- a/src/autolabel/tasks/multilabel_classification.py
+++ b/src/autolabel/tasks/multilabel_classification.py
@@ -9,7 +9,8 @@ from autolabel.confidence import ConfidenceCalculator
 from autolabel.configs import AutolabelConfig
 from autolabel.schema import LLMAnnotation, Metric, MetricResult
 from autolabel.tasks import BaseTask
-from autolabel.utils import get_format_variables, compute_f1
+from autolabel.tasks.utils import compute_f1
+from autolabel.utils import get_format_variables
 
 import json
 

--- a/src/autolabel/tasks/multilabel_classification.py
+++ b/src/autolabel/tasks/multilabel_classification.py
@@ -2,8 +2,7 @@ from collections import defaultdict
 from typing import List, Dict, Tuple
 
 from langchain.prompts.prompt import PromptTemplate
-from sklearn.metrics import accuracy_score, f1_score
-from sklearn.preprocessing import MultiLabelBinarizer
+from sklearn.metrics import accuracy_score
 
 from autolabel.confidence import ConfidenceCalculator
 from autolabel.configs import AutolabelConfig

--- a/src/autolabel/tasks/multilabel_classification.py
+++ b/src/autolabel/tasks/multilabel_classification.py
@@ -129,7 +129,8 @@ class MultilabelClassificationTask(BaseTask):
         """
 
         eval_metrics_map = {
-            Metric.F1: [],
+            Metric.F1_MACRO: [],
+            Metric.F1_WEIGHTED: [],
             Metric.SUPPORT: [],
             Metric.ACCURACY: [],
             Metric.COMPLETION_RATE: [],
@@ -177,11 +178,21 @@ class MultilabelClassificationTask(BaseTask):
             if self.config.confidence():
                 eval_metrics_map[Metric.THRESHOLD].append(threshold)
 
-            eval_metrics_map[Metric.F1].append(
+            eval_metrics_map[Metric.F1_MACRO].append(
                 compute_f1(
                     curr_gt_labels,
                     curr_llm_labels,
                     average="macro",
+                    labels=self.config.labels_list(),
+                    sep=self.config.label_separator(),
+                )
+            )
+
+            eval_metrics_map[Metric.F1_WEIGHTED].append(
+                compute_f1(
+                    curr_gt_labels,
+                    curr_llm_labels,
+                    average="weighted",
                     labels=self.config.labels_list(),
                     sep=self.config.label_separator(),
                 )

--- a/src/autolabel/tasks/question_answering.py
+++ b/src/autolabel/tasks/question_answering.py
@@ -166,14 +166,8 @@ class QuestionAnsweringTask(BaseTask):
             if self.config.confidence():
                 eval_metrics_map[Metric.THRESHOLD].append(threshold)
 
-            f1 = sum(
-                [
-                    compute_f1(curr_llm_labels[index], curr_gt_labels[index])
-                    for index in range(len(curr_llm_labels))
-                ]
-            )
             eval_metrics_map[Metric.F1].append(
-                (float(f1) / len(curr_llm_labels)) if len(curr_llm_labels) > 0 else 0.0
+                compute_f1(curr_gt_labels, curr_llm_labels)
             )
 
         eval_metrics.extend(

--- a/src/autolabel/tasks/utils.py
+++ b/src/autolabel/tasks/utils.py
@@ -3,6 +3,7 @@ import re
 from typing import List
 
 from sklearn.metrics import f1_score
+from sklearn.preprocessing import MultiLabelBinarizer
 
 
 def normalize_text(s: str) -> str:

--- a/src/autolabel/tasks/utils.py
+++ b/src/autolabel/tasks/utils.py
@@ -47,15 +47,11 @@ def compute_f1(
     """
     if labels:
         mlb = MultiLabelBinarizer()
-        mlb.fit(labels)
-
-        def binarize_labels(curr_labels):
-            """Generate multilabel array from ground truth and LLM labels"""
-            return mlb.transform([x.split(sep) for x in curr_labels])
+        mlb.fit([labels])
 
         return f1_score(
-            binarize_labels(truth),
-            binarize_labels(prediction),
+            mlb.transform([x.split(sep) for x in truth]),
+            mlb.transform([x.split(sep) for x in prediction]),
             average=average,
             zero_division=0,
         )

--- a/tests/unit/tasks_test.py
+++ b/tests/unit/tasks_test.py
@@ -475,8 +475,10 @@ def test_multilabel_classification_eval():
     for metric in eval:
         if metric.metric_type == Metric.ACCURACY:
             assert metric.value[0] == 0.25
-        elif metric.metric_type == Metric.F1:
+        elif metric.metric_type == Metric.F1_MACRO:
             assert metric.value[0] == 0.25
+        elif metric.metric_type == Metric.F1_WEIGHTED:
+            assert metric.value[0] == 5 / 9
         elif metric.metric_type == Metric.COMPLETION_RATE:
             assert metric.value[0] == 0.8
         elif metric.metric_type == Metric.SUPPORT:


### PR DESCRIPTION
`compute_f1` now takes in the entire list of gt labels and llm labels instead of just one at a time. The binarization is also done in `compute_f1` for multilabel classification. This directly addresses #409.