### PR TITLE
added output cost calculation to PaLM get_cost

### DIFF
--- a/src/autolabel/models/palm.py
+++ b/src/autolabel/models/palm.py
@@ -127,7 +127,7 @@ class PaLMLLM(BaseModel):
             return 0.0
         cost_per_char = self.COST_PER_CHARACTER.get(self.model_name, 0.0)
         return cost_per_char * len(prompt) + cost_per_char * (
-            len(label) if label else self.config.model_params["max_output_tokens"]
+            len(label) if label else 4 * self.config.model_params["max_output_tokens"]
         )
 
     def returns_token_probs(self) -> bool:

--- a/src/autolabel/models/palm.py
+++ b/src/autolabel/models/palm.py
@@ -127,7 +127,7 @@ class PaLMLLM(BaseModel):
             return 0.0
         cost_per_char = self.COST_PER_CHARACTER.get(self.model_name, 0.0)
         return cost_per_char * len(prompt) + cost_per_char * (
-            len(label) if label else 4 * self.config.model_params["max_output_tokens"]
+            len(label) if label else 4 * self.model_params["max_output_tokens"]
         )
 
     def returns_token_probs(self) -> bool:

--- a/src/autolabel/models/palm.py
+++ b/src/autolabel/models/palm.py
@@ -25,7 +25,8 @@ class PaLMLLM(BaseModel):
     CHAT_ENGINE_MODELS = ["chat-bison@001"]
 
     DEFAULT_MODEL = "text-bison@001"
-    DEFAULT_PARAMS = {"temperature": 0}
+    # Reference: https://developers.generativeai.google/guide/concepts#model_parameters for "A token is approximately 4 characters"
+    DEFAULT_PARAMS = {"temperature": 0, "max_output_tokens": 1000}
 
     # Reference: https://cloud.google.com/vertex-ai/pricing
     COST_PER_CHARACTER = {
@@ -125,7 +126,9 @@ class PaLMLLM(BaseModel):
         if self.model_name is None:
             return 0.0
         cost_per_char = self.COST_PER_CHARACTER.get(self.model_name, 0.0)
-        return cost_per_char * len(prompt)
+        return cost_per_char * len(prompt) + cost_per_char * (
+            len(label) if label else self.config.model_params["max_output_tokens"]
+        )
 
     def returns_token_probs(self) -> bool:
         return False

--- a/tests/unit/llm_test.py
+++ b/tests/unit/llm_test.py
@@ -168,7 +168,7 @@ def test_palm_label(mocker):
     )
     x = model.label(prompts)
     assert [i[0].text for i in x[0].generations] == ["Answers", "Answers"]
-    assert x[1] == approx(9.9999e-06, rel=1e-3)
+    assert x[1] == approx(2.4e-05, rel=1e-3)
 
 
 def test_palm_get_cost(mocker):
@@ -181,7 +181,7 @@ def test_palm_get_cost(mocker):
     )
     example_prompt = "TestingExamplePrompt"
     curr_cost = model.get_cost(example_prompt)
-    assert curr_cost == approx(1.9999e-05, rel=1e-3)
+    assert curr_cost == approx(3.4e-05, rel=1e-3)
 
 
 def test_palm_return_probs(mocker):

--- a/tests/unit/llm_test.py
+++ b/tests/unit/llm_test.py
@@ -181,7 +181,7 @@ def test_palm_get_cost(mocker):
     )
     example_prompt = "TestingExamplePrompt"
     curr_cost = model.get_cost(example_prompt)
-    assert curr_cost == approx(3.4e-05, rel=1e-3)
+    assert curr_cost == approx(0.00402, rel=1e-3)
 
 
 def test_palm_return_probs(mocker):


### PR DESCRIPTION
Previously, we were not calculating the output costs of the PALM model. Added a default `max_output_tokens` param and output token calculation into `get_cost`.