### PR TITLE
Bubble up errors and clean up error creation

### DIFF
--- a/src/autolabel/confidence.py
+++ b/src/autolabel/confidence.py
@@ -86,7 +86,7 @@ class ConfidenceCalculator:
                 return -math.e ** token[token_str]
         return 0
 
-    def calculate(self, model_generation: LLMAnnotation, **kwargs) -> LLMAnnotation:
+    def calculate(self, model_generation: LLMAnnotation, **kwargs) -> float:
         if self.score_type not in self.SUPPORTED_CALCULATORS:
             raise NotImplementedError()
 
@@ -110,8 +110,7 @@ class ConfidenceCalculator:
             logprobs=logprobs,
             **kwargs,
         )
-        model_generation.confidence_score = confidence
-        return model_generation
+        return confidence
 
     @retry(
         reraise=True,

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -187,7 +187,7 @@ class LabelingAgent:
                     self.task_run.id,
                 )
 
-            cost += response.cost
+            cost += sum(response.costs)
             postfix_dict[self.COST_KEY] = f"{cost:.2f}"
 
             # Evaluate the task every eval_every examples

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 from typing import Dict, List, Optional, Tuple, Union
+import json
 
 import numpy as np
 import pandas as pd
@@ -157,12 +158,10 @@ class LabelingAgent:
                         successfully_labeled=False,
                         label=self.task.NULL_LABEL_TOKEN,
                         raw_response="",
-                        curr_sample=chunk,
+                        curr_sample=json.dumps(chunk),
                         prompt=final_prompt,
                         confidence_score=0,
-                        error=LabelingError(
-                            error_type=ErrorType.LLM_ERROR, error_message=str(error)
-                        ),
+                        error=error,
                     )
                 else:
                     annotations = []

--- a/src/autolabel/models/anthropic.py
+++ b/src/autolabel/models/anthropic.py
@@ -6,6 +6,7 @@ from autolabel.models import BaseModel
 from autolabel.cache import BaseCache
 from langchain.chat_models import ChatAnthropic
 from langchain.schema import LLMResult, HumanMessage
+from autolabel.schema import RefuelLLMResult
 
 
 class AnthropicLLM(BaseModel):
@@ -37,10 +38,13 @@ class AnthropicLLM(BaseModel):
         # initialize LLM
         self.llm = ChatAnthropic(model=self.model_name, **self.model_params)
 
-    def _label(self, prompts: List[str]) -> LLMResult:
+    def _label(self, prompts: List[str]) -> RefuelLLMResult:
         prompts = [[HumanMessage(content=prompt)] for prompt in prompts]
         try:
-            return self.llm.generate(prompts)
+            result = self.llm.generate(prompts)
+            return RefuelLLMResult(
+                generations=result.generations, errors=[None] * len(result.generations)
+            )
         except Exception as e:
             return self._label_individually(prompts)
 

--- a/src/autolabel/models/anthropic.py
+++ b/src/autolabel/models/anthropic.py
@@ -42,7 +42,6 @@ class AnthropicLLM(BaseModel):
         try:
             return self.llm.generate(prompts)
         except Exception as e:
-            print(f"Error generating from LLM: {e}, retrying each prompt individually")
             return self._label_individually(prompts)
 
     def get_cost(self, prompt: str, label: Optional[str] = "") -> float:

--- a/src/autolabel/models/base.py
+++ b/src/autolabel/models/base.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Dict, Tuple
 from langchain.schema import LLMResult, Generation
 
 from autolabel.configs import AutolabelConfig
-from autolabel.schema import CacheEntry
+from autolabel.schema import CacheEntry, LabelingError, RefuelLLMResult, ErrorType
 from autolabel.cache import BaseCache
 
 
@@ -18,13 +18,13 @@ class BaseModel(ABC):
         # Specific classes that implement this interface should run initialization steps here
         # E.g. initializing the LLM model with required parameters from ModelConfig
 
-    def label(self, prompts: List[str]) -> Tuple[LLMResult, float]:
+    def label(self, prompts: List[str]) -> RefuelLLMResult:
         """Label a list of prompts."""
         existing_prompts = {}
         missing_prompt_idxs = list(range(len(prompts)))
         missing_prompts = prompts
-        llm_output = {}
         cost = 0.0
+        errors = [None for i in range(len(prompts))]
         if self.cache:
             (
                 existing_prompts,
@@ -41,18 +41,19 @@ class BaseModel(ABC):
                 )
 
             # Set the existing prompts to the new results
-            for i, result in zip(missing_prompt_idxs, new_results.generations):
+            for i, result, error in zip(
+                missing_prompt_idxs, new_results.generation, new_results.errors
+            ):
                 existing_prompts[i] = result
+                errors[i] = error
 
             if self.cache:
                 self.update_cache(missing_prompt_idxs, new_results, prompts)
 
-            llm_output = new_results.llm_output
-
         generations = [existing_prompts[i] for i in range(len(prompts))]
-        return LLMResult(generations=generations, llm_output=llm_output), cost
+        return RefuelLLMResult(generations=generations, cost=cost, errors=errors)
 
-    def _label_individually(self, prompts: List[str]) -> LLMResult:
+    def _label_individually(self, prompts: List[str]) -> RefuelLLMResult:
         """Label each prompt individually. Should be used only after trying as a batch first.
 
         Args:
@@ -60,20 +61,28 @@ class BaseModel(ABC):
 
         Returns:
             LLMResult: LLMResult object with generations
+            List[LabelingError]: List of errors encountered while labeling
         """
         generations = []
+        errors = []
         for prompt in prompts:
             try:
                 response = self.llm.generate([prompt])
                 generations.append(response.generations[0])
+                errors.append(None)
             except Exception as e:
-                print(f"Error generating from LLM: {e}, returning empty generation")
+                print(f"Error generating from LLM: {e}")
                 generations.append([Generation(text="")])
+                errors.append(
+                    LabelingError(
+                        error_type=ErrorType.LLM_PROVIDER_ERROR, error_message=str(e)
+                    )
+                )
 
-        return LLMResult(generations=generations)
+        return RefuelLLMResult(generations=generations, errors=errors)
 
     @abstractmethod
-    def _label(self, prompts: List[str]) -> LLMResult:
+    def _label(self, prompts: List[str]) -> RefuelLLMResult:
         # TODO: change return type to do parsing in the Model class
         pass
 
@@ -113,10 +122,11 @@ class BaseModel(ABC):
             sorted([(k, v) for k, v in self.model_params.items()])
         )
 
-        for i, result in zip(missing_prompt_idxs, new_results.generations):
-            # If the result is empty, don't cache it
-            # This result was likely produced due to an error
-            if result[0].text == "":
+        for i, result, error in zip(
+            missing_prompt_idxs, new_results.generations, new_results.errors
+        ):
+            # If there was an error, don't cache the result
+            if error is not None:
                 continue
 
             cache_entry = CacheEntry(

--- a/src/autolabel/models/base.py
+++ b/src/autolabel/models/base.py
@@ -42,7 +42,7 @@ class BaseModel(ABC):
 
             # Set the existing prompts to the new results
             for i, result, error in zip(
-                missing_prompt_idxs, new_results.generation, new_results.errors
+                missing_prompt_idxs, new_results.generations, new_results.errors
             ):
                 existing_prompts[i] = result
                 errors[i] = error

--- a/src/autolabel/models/base.py
+++ b/src/autolabel/models/base.py
@@ -23,7 +23,7 @@ class BaseModel(ABC):
         existing_prompts = {}
         missing_prompt_idxs = list(range(len(prompts)))
         missing_prompts = prompts
-        cost = 0.0
+        costs = []
         errors = [None for i in range(len(prompts))]
         if self.cache:
             (
@@ -36,8 +36,8 @@ class BaseModel(ABC):
         if len(missing_prompts) > 0:
             new_results = self._label(missing_prompts)
             for ind, prompt in enumerate(missing_prompts):
-                cost += self.get_cost(
-                    prompt, label=new_results.generations[ind][0].text
+                costs.append(
+                    self.get_cost(prompt, label=new_results.generations[ind][0].text)
                 )
 
             # Set the existing prompts to the new results
@@ -51,7 +51,7 @@ class BaseModel(ABC):
                 self.update_cache(missing_prompt_idxs, new_results, prompts)
 
         generations = [existing_prompts[i] for i in range(len(prompts))]
-        return RefuelLLMResult(generations=generations, cost=cost, errors=errors)
+        return RefuelLLMResult(generations=generations, costs=costs, errors=errors)
 
     def _label_individually(self, prompts: List[str]) -> RefuelLLMResult:
         """Label each prompt individually. Should be used only after trying as a batch first.

--- a/src/autolabel/models/cohere.py
+++ b/src/autolabel/models/cohere.py
@@ -10,6 +10,7 @@ from langchain import PromptTemplate, LLMChain
 from autolabel.models import BaseModel
 from autolabel.configs import AutolabelConfig
 from autolabel.cache import BaseCache
+from autolabel.schema import RefuelLLMResult
 
 
 class CohereLLM(BaseModel):
@@ -37,9 +38,12 @@ class CohereLLM(BaseModel):
         self.llm = Cohere(model=self.model_name, **self.model_params)
         self.co = cohere.Client(api_key=os.environ["COHERE_API_KEY"])
 
-    def _label(self, prompts: List[str]) -> LLMResult:
+    def _label(self, prompts: List[str]) -> RefuelLLMResult:
         try:
-            return self.llm.generate(prompts)
+            result = self.llm.generate(prompts)
+            return RefuelLLMResult(
+                generations=result.generations, errors=[None] * len(result.generations)
+            )
         except Exception as e:
             return self._label_individually(prompts)
 

--- a/src/autolabel/models/cohere.py
+++ b/src/autolabel/models/cohere.py
@@ -41,7 +41,6 @@ class CohereLLM(BaseModel):
         try:
             return self.llm.generate(prompts)
         except Exception as e:
-            print(f"Error generating from LLM: {e}, retrying each prompt individually")
             return self._label_individually(prompts)
 
     def get_cost(self, prompt: str, label: Optional[str] = "") -> float:

--- a/src/autolabel/models/hf_pipeline.py
+++ b/src/autolabel/models/hf_pipeline.py
@@ -69,7 +69,6 @@ class HFPipelineLLM(BaseModel):
         try:
             return self.llm.generate(prompts)
         except Exception as e:
-            print(f"Error generating from LLM: {e}, retrying each prompt individually")
             return self._label_individually(prompts)
 
     def get_cost(self, prompt: str, label: Optional[str] = "") -> float:

--- a/src/autolabel/models/hf_pipeline.py
+++ b/src/autolabel/models/hf_pipeline.py
@@ -5,6 +5,7 @@ from langchain.schema import LLMResult
 from autolabel.models import BaseModel
 from autolabel.configs import AutolabelConfig
 from autolabel.cache import BaseCache
+from autolabel.schema import RefuelLLMResult
 
 
 class HFPipelineLLM(BaseModel):
@@ -65,9 +66,12 @@ class HFPipelineLLM(BaseModel):
         # initialize LLM
         self.llm = HuggingFacePipeline(pipeline=pipe, model_kwargs=model_kwargs)
 
-    def _label(self, prompts: List[str]) -> LLMResult:
+    def _label(self, prompts: List[str]) -> RefuelLLMResult:
         try:
-            return self.llm.generate(prompts)
+            result = self.llm.generate(prompts)
+            return RefuelLLMResult(
+                generations=result.generations, errors=[None] * len(result.generations)
+            )
         except Exception as e:
             return self._label_individually(prompts)
 

--- a/src/autolabel/models/openai.py
+++ b/src/autolabel/models/openai.py
@@ -146,7 +146,6 @@ class OpenAILLM(BaseModel):
         try:
             return self.llm.generate(prompts)
         except Exception as e:
-            print(f"Error generating from LLM: {e}, retrying each prompt individually")
             return self._label_individually(prompts)
 
     def get_cost(self, prompt: str, label: Optional[str] = "") -> float:

--- a/src/autolabel/models/palm.py
+++ b/src/autolabel/models/palm.py
@@ -9,6 +9,7 @@ from langchain.schema import LLMResult, HumanMessage, Generation
 from autolabel.models import BaseModel
 from autolabel.configs import AutolabelConfig
 from autolabel.cache import BaseCache
+from autolabel.schema import RefuelLLMResult
 
 from tenacity import (
     before_sleep_log,
@@ -91,7 +92,7 @@ class PaLMLLM(BaseModel):
 
         return LLMResult(generations=generations)
 
-    def _label(self, prompts: List[str]) -> LLMResult:
+    def _label(self, prompts: List[str]) -> RefuelLLMResult:
         for prompt in prompts:
             if self.SEP_REPLACEMENT_TOKEN in prompt:
                 logger.warning(
@@ -117,7 +118,9 @@ class PaLMLLM(BaseModel):
                     generation.text = generation.text.replace(
                         self.SEP_REPLACEMENT_TOKEN, "\n"
                     )
-            return result
+            return RefuelLLMResult(
+                generations=result.generations, errors=[None] * len(result.generations)
+            )
         except Exception as e:
             self._label_individually(prompts)
 

--- a/src/autolabel/models/palm.py
+++ b/src/autolabel/models/palm.py
@@ -119,7 +119,6 @@ class PaLMLLM(BaseModel):
                     )
             return result
         except Exception as e:
-            print(f"Error generating from LLM: {e}, retrying each prompt individually")
             self._label_individually(prompts)
 
     def get_cost(self, prompt: str, label: Optional[str] = "") -> float:

--- a/src/autolabel/models/refuel.py
+++ b/src/autolabel/models/refuel.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 from autolabel.models import BaseModel
 from autolabel.configs import AutolabelConfig
 from autolabel.cache import BaseCache
+from autolabel.schema import LabelingError, ErrorType
 
 
 from tenacity import (
@@ -67,6 +68,7 @@ class RefuelLLM(BaseModel):
 
     def _label(self, prompts: List[str]) -> LLMResult:
         generations = []
+        errors = []
         for prompt in prompts:
             try:
                 if self.SEP_REPLACEMENT_TOKEN in prompt:
@@ -83,13 +85,17 @@ class RefuelLLM(BaseModel):
                     self.SEP_REPLACEMENT_TOKEN, "\n"
                 )
                 generations.append([Generation(text=response)])
+                errors.append(None)
             except Exception as e:
                 # This signifies an error in generating the response using RefuelLLm
                 logger.error(
                     f"Unable to generate prediction: {e}",
                 )
                 generations.append([Generation(text="")])
-        return LLMResult(generations=generations)
+                errors.append(
+                    LabelingError(error_type=ErrorType.LLM_PROVIDER_ERROR, error=e)
+                )
+        return LLMResult(generations=generations, errors=errors)
 
     def get_cost(self, prompt: str, label: Optional[str] = "") -> float:
         return 0

--- a/src/autolabel/models/refuel.py
+++ b/src/autolabel/models/refuel.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 from autolabel.models import BaseModel
 from autolabel.configs import AutolabelConfig
 from autolabel.cache import BaseCache
-from autolabel.schema import LabelingError, ErrorType
+from autolabel.schema import LabelingError, ErrorType, RefuelLLMResult
 
 
 from tenacity import (
@@ -66,7 +66,7 @@ class RefuelLLM(BaseModel):
         response.raise_for_status()
         return response
 
-    def _label(self, prompts: List[str]) -> LLMResult:
+    def _label(self, prompts: List[str]) -> RefuelLLMResult:
         generations = []
         errors = []
         for prompt in prompts:
@@ -95,7 +95,7 @@ class RefuelLLM(BaseModel):
                 errors.append(
                     LabelingError(error_type=ErrorType.LLM_PROVIDER_ERROR, error=e)
                 )
-        return LLMResult(generations=generations, errors=errors)
+        return RefuelLLMResult(generations=generations, errors=errors)
 
     def get_cost(self, prompt: str, label: Optional[str] = "") -> float:
         return 0

--- a/src/autolabel/schema.py
+++ b/src/autolabel/schema.py
@@ -198,7 +198,7 @@ class RefuelLLMResult(BaseModel):
     generations: List[List[Generation]]
 
     """Errors encountered while running the labeling job"""
-    errors: List[LabelingError]
+    errors: List[Optional[LabelingError]]
 
     """Costs incurred during the labeling job"""
-    costs: Optional[float] = 0.0
+    cost: Optional[float] = 0.0

--- a/src/autolabel/schema.py
+++ b/src/autolabel/schema.py
@@ -71,6 +71,22 @@ class MetricResult(BaseModel):
     value: Any
 
 
+class ErrorType(str, Enum):
+    """Enum of supported error types"""
+
+    LLM_PROVIDER_ERROR = "llm_provider_error"
+    PARSING_ERROR = "parsing_error"
+    OUTPUT_GUIDELINES_NOT_FOLLOWED_ERROR = "output_guidelines_not_followed_error"
+    EMPTY_RESPONSE_ERROR = "empty_response_error"
+
+
+class LabelingError(BaseModel):
+    """Contains information about an error that occurred during the labeling process"""
+
+    error_type: ErrorType
+    error_message: str
+
+
 class LLMAnnotation(BaseModel):
     """Contains label information of a given data point, including the generated label, the prompt given to the LLM, and the LLMs response. Optionally includes a confidence_score if supported by the model"""
 
@@ -82,6 +98,7 @@ class LLMAnnotation(BaseModel):
     raw_response: Optional[str] = ""
     explanation: Optional[str] = ""
     prompt: Optional[str] = ""
+    error: Optional[LabelingError] = None
 
 
 class Dataset(BaseModel):
@@ -172,3 +189,16 @@ class CacheEntry(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class RefuelLLMResult(BaseModel):
+    """List of generated outputs. This is a List[List[]] because
+    each input could have multiple candidate generations."""
+
+    generations: List[List[Generation]]
+
+    """Errors encountered while running the labeling job"""
+    errors: List[LabelingError]
+
+    """Costs incurred during the labeling job"""
+    costs: Optional[float] = 0.0

--- a/src/autolabel/schema.py
+++ b/src/autolabel/schema.py
@@ -201,4 +201,4 @@ class RefuelLLMResult(BaseModel):
     errors: List[Optional[LabelingError]]
 
     """Costs incurred during the labeling job"""
-    cost: Optional[float] = 0.0
+    costs: Optional[List[float]] = []

--- a/src/autolabel/tasks/base.py
+++ b/src/autolabel/tasks/base.py
@@ -92,7 +92,7 @@ class BaseTask(ABC):
             logger.warning("LLM response is empty")
             error = LabelingError(
                 error_type=ErrorType.EMPTY_RESPONSE_ERROR,
-                message="Empty response from LLM",
+                error_message="Empty response from LLM",
             )
         elif not completion_text:
             successfully_labeled = False

--- a/src/autolabel/tasks/base.py
+++ b/src/autolabel/tasks/base.py
@@ -8,7 +8,14 @@ import json
 from langchain.prompts.prompt import PromptTemplate
 from langchain.schema import Generation
 from autolabel.configs import AutolabelConfig
-from autolabel.schema import LLMAnnotation, MetricResult, FewShotAlgorithm, TaskType
+from autolabel.schema import (
+    LLMAnnotation,
+    MetricResult,
+    FewShotAlgorithm,
+    TaskType,
+    LabelingError,
+    ErrorType,
+)
 from autolabel.utils import get_format_variables, extract_valid_json_substring
 
 logger = logging.getLogger(__name__)
@@ -67,6 +74,7 @@ class BaseTask(ABC):
     ) -> LLMAnnotation:
         # The last line of the response is the label
         # This is done to handle the case where the model generates an explanation before generating the label
+        error = None
         if self.config.chain_of_thought():
             try:
                 explanation = response.text.strip().split("\n")[0].strip()
@@ -81,11 +89,19 @@ class BaseTask(ABC):
         if len(response.text.strip()) == 0:
             successfully_labeled = False
             llm_label = self.NULL_LABEL_TOKEN
-            logger.warning(f"LLM response is empty")
+            logger.warning("LLM response is empty")
+            error = LabelingError(
+                error_type=ErrorType.EMPTY_RESPONSE_ERROR,
+                message="Empty response from LLM",
+            )
         elif not completion_text:
             successfully_labeled = False
             llm_label = self.NULL_LABEL_TOKEN
-            logger.error(f"Error parsing LLM response: {response.text}")
+            logger.warning(f"Error parsing LLM response: {response.text}")
+            error = LabelingError(
+                error_type=ErrorType.PARSING_ERROR,
+                error_message=f"Error parsing LLM response: {response.text}",
+            )
         else:
             llm_label = completion_text.strip()
             if self.config.task_type() in [
@@ -97,6 +113,10 @@ class BaseTask(ABC):
                 else:
                     logger.warning(f"LLM response is not in the labels list")
                     successfully_labeled = False
+                    error = LabelingError(
+                        error_type=ErrorType.OUTPUT_GUIDELINES_NOT_FOLLOWED_ERROR,
+                        error_message=f"LLM response is not in the labels list: {llm_label}",
+                    )
             else:
                 successfully_labeled = True
 
@@ -108,4 +128,5 @@ class BaseTask(ABC):
             prompt=prompt,
             curr_sample=json.dumps(curr_sample),
             explanation=explanation if self.config.chain_of_thought() else "",
+            error=error,
         )

--- a/tests/unit/llm_test.py
+++ b/tests/unit/llm_test.py
@@ -30,8 +30,8 @@ def test_anthropic_label(mocker):
         ),
     )
     x = model.label(prompts)
-    assert [i[0].text for i in x[0].generations] == ["Answers", "Answers"]
-    assert x[1] == approx(0.00010944, rel=1e-3)
+    assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
+    assert x.cost == approx(0.00010944, rel=1e-3)
 
 
 def test_anthropic_get_cost():
@@ -76,7 +76,7 @@ def test_gpt35_label(mocker):
         ),
     )
     x = model.label(prompts)
-    assert [i[0].text for i in x[0].generations] == ["Answers", "Answers"]
+    assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
 
 
 def test_gpt35_get_cost():
@@ -117,8 +117,8 @@ def test_gpt4_label(mocker):
         ),
     )
     x = model.label(prompts)
-    assert [i[0].text for i in x[0].generations] == ["Answers", "Answers"]
-    assert x[1] == approx(0.00023999, rel=1e-3)
+    assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
+    assert x.cost == approx(0.00023999, rel=1e-3)
 
 
 def test_gpt4_get_cost():
@@ -167,8 +167,8 @@ def test_palm_label(mocker):
         ),
     )
     x = model.label(prompts)
-    assert [i[0].text for i in x[0].generations] == ["Answers", "Answers"]
-    assert x[1] == approx(2.4e-05, rel=1e-3)
+    assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
+    assert x.cost == approx(2.4e-05, rel=1e-3)
 
 
 def test_palm_get_cost(mocker):
@@ -225,8 +225,8 @@ def test_refuel_label(mocker):
         return_value=PostRequestMockResponse(resp='"Answers"'),
     )
     x = model.label(prompts)
-    assert [i[0].text for i in x[0].generations] == ["Answers", "Answers"]
-    assert x[1] == 0
+    assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
+    assert x.cost == 0
 
 
 def test_refuel_get_cost():

--- a/tests/unit/llm_test.py
+++ b/tests/unit/llm_test.py
@@ -31,7 +31,7 @@ def test_anthropic_label(mocker):
     )
     x = model.label(prompts)
     assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
-    assert x.cost == approx(0.00010944, rel=1e-3)
+    assert sum(x.costs) == approx(0.00010944, rel=1e-3)
 
 
 def test_anthropic_get_cost():
@@ -118,7 +118,7 @@ def test_gpt4_label(mocker):
     )
     x = model.label(prompts)
     assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
-    assert x.cost == approx(0.00023999, rel=1e-3)
+    assert sum(x.costs) == approx(0.00023999, rel=1e-3)
 
 
 def test_gpt4_get_cost():
@@ -168,7 +168,7 @@ def test_palm_label(mocker):
     )
     x = model.label(prompts)
     assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
-    assert x.cost == approx(2.4e-05, rel=1e-3)
+    assert sum(x.costs) == approx(2.4e-05, rel=1e-3)
 
 
 def test_palm_get_cost(mocker):
@@ -226,7 +226,7 @@ def test_refuel_label(mocker):
     )
     x = model.label(prompts)
     assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
-    assert x.cost == 0
+    assert sum(x.costs) == 0
 
 
 def test_refuel_get_cost():


### PR DESCRIPTION
- Errors have a structure with error type and error message
- Errors sent in addition to text generation
- New RefuelLLMResult which encapsulates text generations, errors and cost
- Confidence calculate now returns a float
- Errors saved along with annotations and saved in the dataframe