### PR TITLE
Metric calculation as a separate class

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -15,4 +15,4 @@ jobs:
       - uses: psf/black@stable
         with:
           options: "--check --verbose"
-          version: "22.3.0"
+          version: "23.3.0"

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -62,7 +62,7 @@ class LabelingAgent:
         output_name: Optional[str] = None,
         start_index: Optional[int] = 0,
         eval_every: Optional[int] = 50,
-        additional_metrics: Optional[List[BaseMetric]] = None,
+        additional_metrics: Optional[List[BaseMetric]] = [],
     ) -> Tuple[pd.Series, pd.DataFrame, List[MetricResult]]:
         """Labels data in a given dataset. Output written to new CSV file.
 

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -18,6 +18,7 @@ from autolabel.data_models import AnnotationModel, TaskRunModel
 from autolabel.database import StateManager
 from autolabel.few_shot import ExampleSelectorFactory
 from autolabel.models import BaseModel, ModelFactory
+from autolabel.metrics import BaseMetric
 from autolabel.schema import (
     LLMAnnotation,
     MetricResult,
@@ -64,6 +65,7 @@ class LabelingAgent:
         output_name: Optional[str] = None,
         start_index: Optional[int] = 0,
         eval_every: Optional[int] = 50,
+        additional_metrics: Optional[List[BaseMetric]] = None,
     ) -> Tuple[pd.Series, pd.DataFrame, List[MetricResult]]:
         """Labels data in a given dataset. Output written to new CSV file.
 
@@ -227,10 +229,10 @@ class LabelingAgent:
             table = {}
             # TODO: serialize and write to file
             for m in eval_result:
-                if isinstance(m.value, list) and len(m.value) > 0:
-                    table[m.name] = m.value
+                if isinstance(m.value, list):
+                    continue
                 else:
-                    print(f"Metric: {m.name}: {maybe_round(m.value)}")
+                    table[m.name] = m.value
             print(f"Actual Cost: {maybe_round(cost)}")
             print_table(table, console=console, default_style=METRIC_TABLE_STYLE)
 
@@ -384,10 +386,11 @@ class LabelingAgent:
             eval_result = self.task.eval(llm_labels, gt_labels)
             table = {}
             for m in eval_result:
-                if isinstance(m.value, list) and len(m.value) > 0:
-                    table[m.name] = m.value
+                if isinstance(m.value, list):
+                    continue
                 else:
-                    print(f"Metric: {m.name}: {m.value}")
+                    table[m.name] = m.value
+
             print_table(table, console=console, default_style=METRIC_TABLE_STYLE)
         pprint(f"{task_run.current_index} examples labeled so far.")
         if len(llm_labels) > 0:

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -202,14 +202,12 @@ class LabelingAgent:
                     )
 
                     for m in eval_result:
-                        if not isinstance(m.value, list) or len(m.value) < 1:
+                        # This is a row wise metric
+                        if isinstance(m.value, list):
                             continue
-                        elif isinstance(m.value[0], float):
-                            postfix_dict[m.name] = f"{m.value[0]:.4f}"
-                        elif isinstance(m.value[0], int):
-                            postfix_dict[m.name] = f"{m.value[0]}"
-                        elif len(m.value[0]) > 0:
-                            postfix_dict[m.name] = f"{m.value[0][0]:.4f}"
+                        postfix_dict[m.name] = (
+                            f"{m.value:.4f}" if isinstance(m.value, float) else m.value
+                        )
 
             # Update task run state
             self.task_run = self.save_task_run_state(

--- a/src/autolabel/metrics/__init__.py
+++ b/src/autolabel/metrics/__init__.py
@@ -1,0 +1,6 @@
+from .base import BaseMetric
+from .accuracy import AccuracyMetric
+from .auroc import AUROCMetric
+from .completion_rate import CompletionRateMetric
+from .support import SupportMetric
+from .f1 import F1Metric

--- a/src/autolabel/metrics/accuracy.py
+++ b/src/autolabel/metrics/accuracy.py
@@ -27,10 +27,10 @@ class AccuracyMetric(BaseMetric):
         else:
             accuracy = 0.0
 
-        self.value = [
+        value = [
             MetricResult(
                 name=MetricType.ACCURACY,
                 value=accuracy,
             )
         ]
-        return self.value
+        return value

--- a/src/autolabel/metrics/accuracy.py
+++ b/src/autolabel/metrics/accuracy.py
@@ -1,0 +1,36 @@
+from typing import List
+
+from sklearn.metrics import accuracy_score
+
+from autolabel.metrics import BaseMetric
+from autolabel.schema import LLMAnnotation, MetricResult, MetricType
+
+
+class AccuracyMetric(BaseMetric):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def compute(
+        self, llm_labels: List[LLMAnnotation], gt_labels: List[str]
+    ) -> List[MetricResult]:
+        filtered_llm_labels = []
+        filtered_gt_labels = []
+        for llm_label, gt_label in zip(llm_labels, gt_labels):
+            if llm_label.error is None and gt_label != "nan":
+                filtered_llm_labels.append(llm_label)
+                filtered_gt_labels.append(gt_label)
+
+        filtered_llm_labels = [llm_label.label for llm_label in filtered_llm_labels]
+
+        if len(filtered_gt_labels) > 0:
+            accuracy = accuracy_score(filtered_gt_labels, filtered_llm_labels)
+        else:
+            accuracy = 0.0
+
+        self.value = [
+            MetricResult(
+                name=MetricType.ACCURACY,
+                value=accuracy,
+            )
+        ]
+        return self.value

--- a/src/autolabel/metrics/auroc.py
+++ b/src/autolabel/metrics/auroc.py
@@ -1,0 +1,37 @@
+from typing import List
+
+from sklearn.metrics import roc_auc_score
+
+from autolabel.metrics import BaseMetric
+from autolabel.schema import LLMAnnotation, MetricResult, MetricType
+
+
+class AUROCMetric(BaseMetric):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def compute(
+        self, llm_labels: List[LLMAnnotation], gt_labels: List[str]
+    ) -> List[MetricResult]:
+        filtered_llm_labels = []
+        filtered_gt_labels = []
+        for llm_label, gt_label in zip(llm_labels, gt_labels):
+            if llm_label.error is None and gt_label != "nan":
+                filtered_llm_labels.append(llm_label)
+                filtered_gt_labels.append(gt_label)
+
+        match = [
+            int(llm_label.label == gt_label)
+            for llm_label, gt_label in zip(filtered_llm_labels, filtered_gt_labels)
+        ]
+        confidence = [llm_label.confidence_score for llm_label in filtered_llm_labels]
+
+        auroc = roc_auc_score(match, confidence)
+
+        self.value = [
+            MetricResult(
+                name=MetricType.AUROC,
+                value=auroc,
+            )
+        ]
+        return self.value

--- a/src/autolabel/metrics/auroc.py
+++ b/src/autolabel/metrics/auroc.py
@@ -28,10 +28,10 @@ class AUROCMetric(BaseMetric):
 
         auroc = roc_auc_score(match, confidence)
 
-        self.value = [
+        value = [
             MetricResult(
                 name=MetricType.AUROC,
                 value=auroc,
             )
         ]
-        return self.value
+        return value

--- a/src/autolabel/metrics/base.py
+++ b/src/autolabel/metrics/base.py
@@ -1,0 +1,17 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from autolabel.schema import LLMAnnotation, MetricResult
+
+
+class BaseMetric(ABC):
+    value: List[MetricResult]
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    @abstractmethod
+    def compute(
+        self, llm_labels: List[LLMAnnotation], gt_labels: List[str]
+    ) -> List[MetricResult]:
+        pass

--- a/src/autolabel/metrics/base.py
+++ b/src/autolabel/metrics/base.py
@@ -5,8 +5,6 @@ from autolabel.schema import LLMAnnotation, MetricResult
 
 
 class BaseMetric(ABC):
-    value: List[MetricResult]
-
     def __init__(self) -> None:
         super().__init__()
 

--- a/src/autolabel/metrics/completion_rate.py
+++ b/src/autolabel/metrics/completion_rate.py
@@ -20,10 +20,10 @@ class CompletionRateMetric(BaseMetric):
             completion_rate = completed / len(llm_labels)
         else:
             completion_rate = 0.0
-        self.value = [
+        value = [
             MetricResult(
                 name=MetricType.COMPLETION_RATE,
                 value=completion_rate,
             )
         ]
-        return self.value
+        return value

--- a/src/autolabel/metrics/completion_rate.py
+++ b/src/autolabel/metrics/completion_rate.py
@@ -1,0 +1,29 @@
+from typing import List
+
+from autolabel.metrics import BaseMetric
+from autolabel.schema import LLMAnnotation, MetricResult, MetricType
+
+
+class CompletionRateMetric(BaseMetric):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def compute(
+        self, llm_labels: List[LLMAnnotation], gt_labels: List[str]
+    ) -> List[MetricResult]:
+        completed = 0
+        for label in llm_labels:
+            if label.error is None:
+                completed += 1
+
+        if len(llm_labels) > 0:
+            completion_rate = completed / len(llm_labels)
+        else:
+            completion_rate = 0.0
+        self.value = [
+            MetricResult(
+                name=MetricType.COMPLETION_RATE,
+                value=completion_rate,
+            )
+        ]
+        return self.value

--- a/src/autolabel/metrics/f1.py
+++ b/src/autolabel/metrics/f1.py
@@ -1,0 +1,105 @@
+from typing import List, Optional
+
+from autolabel.metrics import BaseMetric
+from autolabel.schema import LLMAnnotation, MetricResult, MetricType, F1Type
+from sklearn.preprocessing import MultiLabelBinarizer
+from sklearn.metrics import f1_score
+from autolabel.utils import normalize_text
+
+
+class F1Metric(BaseMetric):
+    def __init__(
+        self,
+        type: F1Type,
+        labels: Optional[List[str]] = [],
+        sep: Optional[str] = " ",
+        average: Optional[List[str]] = [MetricType.F1_MICRO],
+    ) -> None:
+        super().__init__()
+        self.type = type
+        self.labels = labels
+        self.sep = sep
+        self.average = average
+
+    def multi_label_compute(
+        self, llm_labels: List[LLMAnnotation], gt_labels: List[str]
+    ) -> List[MetricResult]:
+        filtered_llm_labels = []
+        filtered_gt_labels = []
+        for llm_label, gt_label in zip(llm_labels, gt_labels):
+            if llm_label.error is None and gt_label != "nan":
+                filtered_llm_labels.append(llm_label)
+                filtered_gt_labels.append(gt_label)
+
+        filtered_llm_labels = [llm_label.label for llm_label in filtered_llm_labels]
+
+        mlb = MultiLabelBinarizer()
+        mlb.fit([self.labels])
+
+        self.value = []
+        for average in self.average:
+            score = f1_score(
+                mlb.transform([x.split(self.sep) for x in gt_labels]),
+                mlb.transform([x.split(self.sep) for x in filtered_llm_labels]),
+                average=average,
+                zero_division=0,
+            )
+            self.value.append(MetricResult(name=average, value=score))
+        return self.value
+
+    def text_compute(
+        self, llm_labels: List[LLMAnnotation], gt_labels: List[str]
+    ) -> List[MetricResult]:
+        truth = [normalize_text(gt_label).split(self.sep) for gt_label in gt_labels]
+        prediction = [
+            normalize_text(llm_label.label).split(self.sep) for llm_label in llm_labels
+        ]
+
+        tp_pairs = zip(truth, prediction)
+
+        f1_scores = []
+        filtered_datapoints = 0
+        for i, (truth_tokens, pred_tokens) in enumerate(tp_pairs):
+            # if there is an error filter this datapoint
+            if llm_labels[i].error is not None or gt_labels[i] == "nan":
+                f1_scores.append(0)
+                filtered_datapoints += 1
+                continue
+
+            # if either the prediction or the truth is no-answer then f1 = 1 if they agree, 0 otherwise
+            if len(truth_tokens) == 0 or len(pred_tokens) == 0:
+                f1_scores.append(int(truth_tokens == pred_tokens))
+                continue
+
+            common_tokens = set(truth_tokens) & set(pred_tokens)
+
+            # if there are no common tokens then f1 = 0
+            if len(common_tokens) == 0:
+                f1_scores.append(0)
+                continue
+
+            rec = len(common_tokens) / len(truth_tokens)
+            prec = len(common_tokens) / len(pred_tokens)
+
+            f1_scores.append(2 * (prec * rec) / (prec + rec))
+
+        self.values = [
+            MetricResult(
+                name=MetricType.TEXT_PARTIAL_MATCH,
+                value=f1_scores,
+            ),
+            MetricResult(
+                name=MetricType.F1,
+                value=sum(f1_scores) / (len(f1_scores) - filtered_datapoints),
+            ),
+        ]
+
+        return self.values
+
+    def compute(
+        self, llm_labels: List[LLMAnnotation], gt_labels: List[str]
+    ) -> List[MetricResult]:
+        if self.type == F1Type.MULTI_LABEL:
+            return self.multi_label_compute(llm_labels, gt_labels)
+        else:
+            return self.text_compute(llm_labels, gt_labels)

--- a/src/autolabel/metrics/f1.py
+++ b/src/autolabel/metrics/f1.py
@@ -36,7 +36,7 @@ class F1Metric(BaseMetric):
         mlb = MultiLabelBinarizer()
         mlb.fit([self.labels])
 
-        self.value = []
+        value = []
         for average in self.average:
             score = f1_score(
                 mlb.transform([x.split(self.sep) for x in filtered_gt_labels]),
@@ -44,8 +44,8 @@ class F1Metric(BaseMetric):
                 average=average,
                 zero_division=0,
             )
-            self.value.append(MetricResult(name=average, value=score))
-        return self.value
+            value.append(MetricResult(name=average, value=score))
+        return value
 
     def text_compute(
         self, llm_labels: List[LLMAnnotation], gt_labels: List[str]
@@ -83,7 +83,7 @@ class F1Metric(BaseMetric):
 
             f1_scores.append(2 * (prec * rec) / (prec + rec))
 
-        self.values = [
+        values = [
             MetricResult(
                 name=MetricType.TEXT_PARTIAL_MATCH,
                 value=f1_scores,
@@ -94,7 +94,7 @@ class F1Metric(BaseMetric):
             ),
         ]
 
-        return self.values
+        return values
 
     def compute(
         self, llm_labels: List[LLMAnnotation], gt_labels: List[str]

--- a/src/autolabel/metrics/f1.py
+++ b/src/autolabel/metrics/f1.py
@@ -41,7 +41,7 @@ class F1Metric(BaseMetric):
             score = f1_score(
                 mlb.transform([x.split(self.sep) for x in filtered_gt_labels]),
                 mlb.transform([x.split(self.sep) for x in filtered_llm_labels]),
-                average=average,
+                average=average.split("_")[-1],
                 zero_division=0,
             )
             value.append(MetricResult(name=average, value=score))

--- a/src/autolabel/metrics/f1.py
+++ b/src/autolabel/metrics/f1.py
@@ -39,7 +39,7 @@ class F1Metric(BaseMetric):
         self.value = []
         for average in self.average:
             score = f1_score(
-                mlb.transform([x.split(self.sep) for x in gt_labels]),
+                mlb.transform([x.split(self.sep) for x in filtered_gt_labels]),
                 mlb.transform([x.split(self.sep) for x in filtered_llm_labels]),
                 average=average,
                 zero_division=0,

--- a/src/autolabel/metrics/support.py
+++ b/src/autolabel/metrics/support.py
@@ -11,5 +11,5 @@ class SupportMetric(BaseMetric):
     def compute(
         self, llm_labels: List[LLMAnnotation], gt_labels: List[str]
     ) -> List[MetricResult]:
-        self.value = [MetricResult(name=MetricType.SUPPORT, value=len(llm_labels))]
-        return self.value
+        value = [MetricResult(name=MetricType.SUPPORT, value=len(llm_labels))]
+        return value

--- a/src/autolabel/metrics/support.py
+++ b/src/autolabel/metrics/support.py
@@ -1,0 +1,15 @@
+from typing import List
+
+from autolabel.metrics import BaseMetric
+from autolabel.schema import LLMAnnotation, MetricResult, MetricType
+
+
+class SupportMetric(BaseMetric):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def compute(
+        self, llm_labels: List[LLMAnnotation], gt_labels: List[str]
+    ) -> List[MetricResult]:
+        self.value = [MetricResult(name=MetricType.SUPPORT, value=len(llm_labels))]
+        return self.value

--- a/src/autolabel/schema.py
+++ b/src/autolabel/schema.py
@@ -56,9 +56,9 @@ class MetricType(str, Enum):
     CONFUSION_MATRIX = "confusion_matrix"
     LABEL_DISTRIBUTION = "label_distribution"
     F1 = "f1"
-    F1_MICRO = "micro"
-    F1_MACRO = "macro"
-    F1_WEIGHTED = "weighted"
+    F1_MICRO = "f1_micro"
+    F1_MACRO = "f1_macro"
+    F1_WEIGHTED = "f1_weighted"
     TEXT_PARTIAL_MATCH = "text_partial_match"
     # Confidence metrics
     AUROC = "auroc"

--- a/src/autolabel/schema.py
+++ b/src/autolabel/schema.py
@@ -45,7 +45,7 @@ class TaskStatus(str, Enum):
     ACTIVE = "active"
 
 
-class Metric(str, Enum):
+class MetricType(str, Enum):
     """Enum of supported performance metrics. Some metrics are always available (task agnostic), while others are only supported by certain types of tasks"""
 
     # Task agnostic
@@ -56,17 +56,23 @@ class Metric(str, Enum):
     CONFUSION_MATRIX = "confusion_matrix"
     LABEL_DISTRIBUTION = "label_distribution"
     F1 = "f1"
-    F1_MACRO = "f1_macro"
-    F1_WEIGHTED = "f1_weighted"
+    F1_MICRO = "micro"
+    F1_MACRO = "macro"
+    F1_WEIGHTED = "weighted"
+    TEXT_PARTIAL_MATCH = "text_partial_match"
     # Confidence metrics
     AUROC = "auroc"
     THRESHOLD = "threshold"
 
 
+class F1Type(str, Enum):
+    MULTI_LABEL = "multi_label"
+    TEXT = "text"
+
+
 class MetricResult(BaseModel):
     """Contains performance metrics gathered from autolabeler runs"""
 
-    metric_type: Metric
     name: str
     value: Any
 

--- a/src/autolabel/tasks/classification.py
+++ b/src/autolabel/tasks/classification.py
@@ -6,10 +6,17 @@ from sklearn.metrics import accuracy_score
 
 from autolabel.confidence import ConfidenceCalculator
 from autolabel.configs import AutolabelConfig
-from autolabel.schema import LLMAnnotation, Metric, MetricResult
+from autolabel.schema import LLMAnnotation, MetricType, MetricResult
 from autolabel.tasks import BaseTask
 from autolabel.utils import get_format_variables
 from autolabel.tasks.utils import filter_unlabeled_examples
+from autolabel.metrics import (
+    AccuracyMetric,
+    AUROCMetric,
+    SupportMetric,
+    CompletionRateMetric,
+    BaseMetric,
+)
 
 import json
 
@@ -24,6 +31,12 @@ class ClassificationTask(BaseTask):
 
     def __init__(self, config: AutolabelConfig) -> None:
         super().__init__(config)
+        self.metrics = [
+            AccuracyMetric(),
+            AUROCMetric(),
+            SupportMetric(),
+            CompletionRateMetric(),
+        ]
 
     def construct_prompt(self, input: Dict, examples: List) -> str:
         # Copy over the input so that we can modify it
@@ -95,101 +108,26 @@ class ClassificationTask(BaseTask):
             labeled_example=fmt_example,
         )
 
-    def auroc_score_labels(
-        self, gt_labels, llm_labels
-    ) -> Tuple[List[int], List[float]]:
-        labels = []
-        confidences = []
-        for index, llm_label in enumerate(llm_labels):
-            labels.append(llm_label.label.lower() == gt_labels[index].lower())
-            confidences.append(llm_label.confidence_score)
-
-        return labels, confidences
-
-    def get_labels_predictions_with_threshold(self, gt_labels, llm_labels, threshold):
-        answered_gt_labels, answered_llm_preds = [], []
-        for index, l in enumerate(llm_labels):
-            if l.label != self.NULL_LABEL_TOKEN and (
-                l.confidence_score is None or l.confidence_score >= threshold
-            ):
-                answered_llm_preds.append(l.label.lower())
-                answered_gt_labels.append(gt_labels[index].lower())
-
-        return answered_gt_labels, answered_llm_preds
-
     def eval(
-        self, llm_labels: List[LLMAnnotation], gt_labels: List[str]
+        self,
+        llm_labels: List[LLMAnnotation],
+        gt_labels: List[str],
+        additional_metrics: List[BaseMetric] = [],
     ) -> List[MetricResult]:
         """Evaluate the LLM generated labels by comparing them against ground truth
 
         Args:
             llm_labels (List[LLMAnnotation]): _description_
             gt_labels (List[str]): _description_
+            additional_metrics (List[BaseMetric], optional): The additional metrics to run. Defaults to [].
 
         Returns:
             List[MetricResult]: list of metrics and corresponding values
         """
 
-        eval_metrics_map = {
-            Metric.SUPPORT: [],
-            Metric.ACCURACY: [],
-            Metric.COMPLETION_RATE: [],
-        }
         eval_metrics = []
-        thresholds = []
 
-        if self.config.confidence():
-            eval_metrics_map[Metric.THRESHOLD] = []
-            labels, confidences = self.auroc_score_labels(gt_labels, llm_labels)
-            value, meaningful_thresholds = ConfidenceCalculator.compute_auroc(
-                labels, confidences
-            )
-            thresholds.extend(meaningful_thresholds)
-            eval_metrics.append(
-                MetricResult(
-                    metric_type=Metric.AUROC,
-                    name="auroc",
-                    value=value,
-                )
-            )
-        else:
-            thresholds.append(float("-inf"))
+        for metric in self.metrics + additional_metrics:
+            eval_metrics.extend(metric.compute(llm_labels, gt_labels))
 
-        for index, threshold in enumerate(thresholds):
-            (
-                curr_gt_labels,
-                curr_llm_labels,
-            ) = self.get_labels_predictions_with_threshold(
-                gt_labels, llm_labels, threshold
-            )
-            if len(gt_labels) > 0:
-                eval_metrics_map[Metric.COMPLETION_RATE].append(
-                    len(curr_gt_labels) / float(len(gt_labels))
-                )
-
-            eval_metrics_map[Metric.SUPPORT].append(len(curr_gt_labels))
-            (
-                filtered_curr_gt_labels,
-                filtered_curr_llm_labels,
-            ) = filter_unlabeled_examples(curr_gt_labels, curr_llm_labels)
-            if len(filtered_curr_gt_labels) > 0:
-                eval_metrics_map[Metric.ACCURACY].append(
-                    accuracy_score(filtered_curr_gt_labels, filtered_curr_llm_labels)
-                )
-            else:
-                eval_metrics_map[Metric.ACCURACY].append(0.0)
-
-            if self.config.confidence():
-                eval_metrics_map[Metric.THRESHOLD].append(threshold)
-
-        eval_metrics.extend(
-            [
-                MetricResult(
-                    metric_type=i,
-                    name=i.value,
-                    value=eval_metrics_map[i],
-                )
-                for i in eval_metrics_map.keys()
-            ]
-        )
         return eval_metrics

--- a/src/autolabel/tasks/classification.py
+++ b/src/autolabel/tasks/classification.py
@@ -33,10 +33,12 @@ class ClassificationTask(BaseTask):
         super().__init__(config)
         self.metrics = [
             AccuracyMetric(),
-            AUROCMetric(),
             SupportMetric(),
             CompletionRateMetric(),
         ]
+
+        if self.config.confidence():
+            self.metrics.append(AUROCMetric())
 
     def construct_prompt(self, input: Dict, examples: List) -> str:
         # Copy over the input so that we can modify it

--- a/src/autolabel/tasks/multilabel_classification.py
+++ b/src/autolabel/tasks/multilabel_classification.py
@@ -132,6 +132,6 @@ class MultilabelClassificationTask(BaseTask):
 
         eval_metrics = []
         for metric in self.metrics + additional_metrics:
-            eval_metrics.append(metric.compute(llm_labels, gt_labels))
+            eval_metrics.extend(metric.compute(llm_labels, gt_labels))
 
         return eval_metrics

--- a/src/autolabel/tasks/multilabel_classification.py
+++ b/src/autolabel/tasks/multilabel_classification.py
@@ -2,17 +2,22 @@ from collections import defaultdict
 from typing import List, Dict, Tuple
 
 from langchain.prompts.prompt import PromptTemplate
-from sklearn.metrics import accuracy_score
 
-from autolabel.confidence import ConfidenceCalculator
 from autolabel.configs import AutolabelConfig
-from autolabel.schema import LLMAnnotation, Metric, MetricResult
+from autolabel.schema import LLMAnnotation, MetricType, MetricResult, F1Type
 from autolabel.tasks import BaseTask
-from autolabel.tasks.utils import compute_f1
 from autolabel.utils import get_format_variables
-from autolabel.tasks.utils import filter_unlabeled_examples
 
 import json
+
+from autolabel.metrics import (
+    AccuracyMetric,
+    AUROCMetric,
+    SupportMetric,
+    CompletionRateMetric,
+    F1Metric,
+    BaseMetric,
+)
 
 
 class MultilabelClassificationTask(BaseTask):
@@ -23,6 +28,18 @@ class MultilabelClassificationTask(BaseTask):
 
     def __init__(self, config: AutolabelConfig) -> None:
         super().__init__(config)
+        self.metrics = [
+            AccuracyMetric(),
+            AUROCMetric(),
+            SupportMetric(),
+            CompletionRateMetric(),
+            F1Metric(
+                type=F1Type.MULTI_LABEL,
+                labels=self.config.labels_list(),
+                sep=self.config.label_separator(),
+                average=[MetricType.F1_MACRO, MetricType.F1_WEIGHTED],
+            ),
+        ]
 
     def construct_prompt(self, input: Dict, examples: List) -> str:
         # Copy over the input so that we can modify it
@@ -94,123 +111,25 @@ class MultilabelClassificationTask(BaseTask):
             labeled_example=fmt_example,
         )
 
-    def auroc_score_labels(
-        self, gt_labels, llm_labels
-    ) -> Tuple[List[int], List[float]]:
-        labels = []
-        confidences = []
-        for index, llm_label in enumerate(llm_labels):
-            labels.append(llm_label.label.lower() == gt_labels[index].lower())
-            confidences.append(llm_label.confidence_score)
-
-        return labels, confidences
-
-    def get_labels_predictions_with_threshold(self, gt_labels, llm_labels, threshold):
-        answered_gt_labels, answered_llm_preds = [], []
-        for index, l in enumerate(llm_labels):
-            if l.label != self.NULL_LABEL_TOKEN and (
-                l.confidence_score is None or l.confidence_score >= threshold
-            ):
-                answered_llm_preds.append(l.label.lower())
-                answered_gt_labels.append(gt_labels[index].lower())
-
-        return answered_gt_labels, answered_llm_preds
-
     def eval(
-        self, llm_labels: List[LLMAnnotation], gt_labels: List[str]
+        self,
+        llm_labels: List[LLMAnnotation],
+        gt_labels: List[str],
+        additional_metrics: List[BaseMetric] = [],
     ) -> List[MetricResult]:
         """Evaluate the LLM generated labels by comparing them against ground truth
 
         Args:
             llm_labels (List[LLMAnnotation]): list of LLM generated labels
             gt_labels (List[str]): list of ground truth labels
+            additional_metrics (List[BaseMetric], optional): list of additional metrics to compute. Defaults to [].
 
         Returns:
             List[MetricResult]: list of metrics and corresponding values
         """
 
-        eval_metrics_map = {
-            Metric.F1_MACRO: [],
-            Metric.F1_WEIGHTED: [],
-            Metric.SUPPORT: [],
-            Metric.ACCURACY: [],
-            Metric.COMPLETION_RATE: [],
-        }
         eval_metrics = []
-        thresholds = []
+        for metric in self.metrics + additional_metrics:
+            eval_metrics.append(metric.compute(llm_labels, gt_labels))
 
-        if self.config.confidence():
-            eval_metrics_map[Metric.THRESHOLD] = []
-            labels, confidences = self.auroc_score_labels(gt_labels, llm_labels)
-            value, meaningful_thresholds = ConfidenceCalculator.compute_auroc(
-                labels, confidences
-            )
-            thresholds.extend(meaningful_thresholds)
-            eval_metrics.append(
-                MetricResult(
-                    metric_type=Metric.AUROC,
-                    name="auroc",
-                    value=value,
-                )
-            )
-        else:
-            thresholds.append(float("-inf"))
-
-        for index, threshold in enumerate(thresholds):
-            (
-                curr_gt_labels,
-                curr_llm_labels,
-            ) = self.get_labels_predictions_with_threshold(
-                gt_labels, llm_labels, threshold
-            )
-            if len(gt_labels) > 0:
-                eval_metrics_map[Metric.COMPLETION_RATE].append(
-                    len(curr_gt_labels) / float(len(gt_labels))
-                )
-
-            eval_metrics_map[Metric.SUPPORT].append(len(curr_gt_labels))
-            (
-                filtered_curr_gt_labels,
-                filtered_curr_llm_labels,
-            ) = filter_unlabeled_examples(curr_gt_labels, curr_llm_labels)
-            if len(filtered_curr_gt_labels) > 0:
-                eval_metrics_map[Metric.ACCURACY].append(
-                    accuracy_score(filtered_curr_gt_labels, filtered_curr_llm_labels)
-                )
-            else:
-                eval_metrics_map[Metric.ACCURACY].append(0.0)
-
-            if self.config.confidence():
-                eval_metrics_map[Metric.THRESHOLD].append(threshold)
-
-            eval_metrics_map[Metric.F1_MACRO].append(
-                compute_f1(
-                    filtered_curr_gt_labels,
-                    filtered_curr_llm_labels,
-                    average="macro",
-                    labels=self.config.labels_list(),
-                    sep=self.config.label_separator(),
-                )
-            )
-
-            eval_metrics_map[Metric.F1_WEIGHTED].append(
-                compute_f1(
-                    filtered_curr_gt_labels,
-                    filtered_curr_llm_labels,
-                    average="weighted",
-                    labels=self.config.labels_list(),
-                    sep=self.config.label_separator(),
-                )
-            )
-
-        eval_metrics.extend(
-            [
-                MetricResult(
-                    metric_type=i,
-                    name=i.value,
-                    value=eval_metrics_map[i],
-                )
-                for i in eval_metrics_map.keys()
-            ]
-        )
         return eval_metrics

--- a/src/autolabel/tasks/multilabel_classification.py
+++ b/src/autolabel/tasks/multilabel_classification.py
@@ -30,7 +30,6 @@ class MultilabelClassificationTask(BaseTask):
         super().__init__(config)
         self.metrics = [
             AccuracyMetric(),
-            AUROCMetric(),
             SupportMetric(),
             CompletionRateMetric(),
             F1Metric(
@@ -40,6 +39,9 @@ class MultilabelClassificationTask(BaseTask):
                 average=[MetricType.F1_MACRO, MetricType.F1_WEIGHTED],
             ),
         ]
+
+        if self.config.confidence():
+            self.metrics.append(AUROCMetric())
 
     def construct_prompt(self, input: Dict, examples: List) -> str:
         # Copy over the input so that we can modify it

--- a/src/autolabel/tasks/named_entity_recognition.py
+++ b/src/autolabel/tasks/named_entity_recognition.py
@@ -280,10 +280,7 @@ class NamedEntityRecognitionTask(BaseTask):
             for index in range(len(gt_labels))
         ]
 
-        (
-            curr_gt_labels,
-            curr_llm_labels,
-        ) = self.get_labels_predictions_with_threshold(
+        (curr_gt_labels, curr_llm_labels,) = self.get_labels_predictions_with_threshold(
             gt_labels, llm_labels, float("-inf")
         )
 

--- a/src/autolabel/tasks/named_entity_recognition.py
+++ b/src/autolabel/tasks/named_entity_recognition.py
@@ -280,7 +280,10 @@ class NamedEntityRecognitionTask(BaseTask):
             for index in range(len(gt_labels))
         ]
 
-        (curr_gt_labels, curr_llm_labels,) = self.get_labels_predictions_with_threshold(
+        (
+            curr_gt_labels,
+            curr_llm_labels,
+        ) = self.get_labels_predictions_with_threshold(
             gt_labels, llm_labels, float("-inf")
         )
 

--- a/src/autolabel/tasks/question_answering.py
+++ b/src/autolabel/tasks/question_answering.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Optional
 import json
 
 from langchain.prompts.prompt import PromptTemplate
@@ -7,11 +7,19 @@ from sklearn.metrics import accuracy_score
 
 from autolabel.confidence import ConfidenceCalculator
 from autolabel.configs import AutolabelConfig
-from autolabel.schema import LLMAnnotation, Metric, MetricResult
+from autolabel.schema import LLMAnnotation, MetricType, MetricResult, F1Type
 from autolabel.tasks import BaseTask
-from autolabel.tasks.utils import normalize_text, compute_f1
+from autolabel.tasks.utils import normalize_text
 from autolabel.utils import get_format_variables
 from autolabel.tasks.utils import filter_unlabeled_examples
+from autolabel.metrics import (
+    AccuracyMetric,
+    AUROCMetric,
+    SupportMetric,
+    CompletionRateMetric,
+    F1Metric,
+    BaseMetric,
+)
 
 
 class QuestionAnsweringTask(BaseTask):
@@ -25,6 +33,15 @@ class QuestionAnsweringTask(BaseTask):
 
     def __init__(self, config: AutolabelConfig) -> None:
         super().__init__(config)
+        self.metrics = [
+            AccuracyMetric(),
+            AUROCMetric(),
+            SupportMetric(),
+            CompletionRateMetric(),
+            F1Metric(
+                type=F1Type.TEXT,
+            ),
+        ]
 
     def construct_prompt(self, input: Dict, examples: List[Dict]) -> str:
         # Copy over the input so that we can modify it
@@ -67,31 +84,6 @@ class QuestionAnsweringTask(BaseTask):
                 current_example=current_example,
             )
 
-    def auroc_score_labels(
-        self, gt_labels, llm_labels
-    ) -> Tuple[List[int], List[float]]:
-        labels = []
-        confidences = []
-        for index, llm_label in enumerate(llm_labels):
-            labels.append(
-                normalize_text(llm_label.label.lower())
-                == normalize_text(gt_labels[index].lower())
-            )
-            confidences.append(llm_label.confidence_score)
-
-        return labels, confidences
-
-    def get_labels_predictions_with_threshold(self, gt_labels, llm_labels, threshold):
-        answered_gt_labels, answered_llm_preds = [], []
-        for index, l in enumerate(llm_labels):
-            if l.label != self.NULL_LABEL_TOKEN and (
-                l.confidence_score is None or l.confidence_score >= threshold
-            ):
-                answered_llm_preds.append(normalize_text(l.label.lower()))
-                answered_gt_labels.append(normalize_text(gt_labels[index].lower()))
-
-        return answered_gt_labels, answered_llm_preds
-
     def get_explanation_prompt(self, example: Dict) -> str:
         pt = PromptTemplate(
             input_variables=get_format_variables(self.GENERATE_EXPLANATION_PROMPT),
@@ -106,85 +98,24 @@ class QuestionAnsweringTask(BaseTask):
         )
 
     def eval(
-        self, llm_labels: List[LLMAnnotation], gt_labels: List[str]
+        self,
+        llm_labels: List[LLMAnnotation],
+        gt_labels: List[str],
+        additional_metrics: Optional[List[BaseMetric]] = None,
     ) -> List[MetricResult]:
         """Evaluate the LLM generated labels by comparing them against ground truth
 
         Args:
             llm_labels (List[LLMAnnotation]): _description_
             gt_labels (List[str]): _description_
+            additional_metrics (Optional[List[BaseMetric]], optional): _description_. Defaults to None.
 
         Returns:
             List[MetricResult]: list of metrics and corresponding values
         """
-
-        eval_metrics_map = {
-            Metric.F1: [],
-            Metric.SUPPORT: [],
-            Metric.ACCURACY: [],
-            Metric.COMPLETION_RATE: [],
-        }
         eval_metrics = []
-        thresholds = []
 
-        if self.config.confidence():
-            eval_metrics_map[Metric.THRESHOLD] = []
-            labels, confidences = self.auroc_score_labels(gt_labels, llm_labels)
-            value, meaningful_thresholds = ConfidenceCalculator.compute_auroc(
-                labels, confidences
-            )
-            thresholds.extend(meaningful_thresholds)
-            eval_metrics.append(
-                MetricResult(
-                    metric_type=Metric.AUROC,
-                    name="auroc",
-                    value=value,
-                )
-            )
-        else:
-            thresholds.append(float("-inf"))
+        for metric in self.metrics + additional_metrics:
+            eval_metrics.append(metric.compute(llm_labels, gt_labels))
 
-        for index, threshold in enumerate(thresholds):
-            (
-                curr_gt_labels,
-                curr_llm_labels,
-            ) = self.get_labels_predictions_with_threshold(
-                gt_labels, llm_labels, threshold
-            )
-            if len(gt_labels) > 0:
-                eval_metrics_map[Metric.COMPLETION_RATE].append(
-                    len(curr_gt_labels) / float(len(gt_labels))
-                )
-
-            eval_metrics_map[Metric.SUPPORT].append(len(curr_gt_labels))
-
-            (
-                filtered_curr_gt_labels,
-                filtered_curr_llm_labels,
-            ) = filter_unlabeled_examples(curr_gt_labels, curr_llm_labels)
-
-            if len(filtered_curr_gt_labels) > 0:
-                eval_metrics_map[Metric.ACCURACY].append(
-                    accuracy_score(filtered_curr_gt_labels, filtered_curr_llm_labels)
-                )
-            else:
-                eval_metrics_map[Metric.ACCURACY].append(0.0)
-
-            if self.config.confidence():
-                eval_metrics_map[Metric.THRESHOLD].append(threshold)
-
-            eval_metrics_map[Metric.F1].append(
-                compute_f1(filtered_curr_gt_labels, filtered_curr_llm_labels)
-            )
-
-        eval_metrics.extend(
-            [
-                MetricResult(
-                    metric_type=i,
-                    name=i.value,
-                    value=eval_metrics_map[i],
-                )
-                for i in eval_metrics_map.keys()
-            ]
-        )
         return eval_metrics

--- a/src/autolabel/tasks/utils.py
+++ b/src/autolabel/tasks/utils.py
@@ -27,61 +27,61 @@ def normalize_text(s: str) -> str:
     return white_space_fix(remove_articles(remove_punc(lower(s))))
 
 
-def compute_f1(
-    truth: List,
-    prediction: List,
-    average: str = "micro",
-    labels: List[str] = None,
-    sep: str = None,
-) -> float:
-    """
-    Compute f1 scores based on given ground truth labels.
+# def compute_f1(
+#     truth: List,
+#     prediction: List,
+#     average: str = "micro",
+#     labels: List[str] = None,
+#     sep: str = None,
+# ) -> float:
+#     """
+#     Compute f1 scores based on given ground truth labels.
 
-    If labels are provided, uses sklearn to binarize the labels and compute f1 scores.
-    Otherwise, uses bag of words approach to compute f1 scores.
+#     If labels are provided, uses sklearn to binarize the labels and compute f1 scores.
+#     Otherwise, uses bag of words approach to compute f1 scores.
 
-    Args:
-        prediction: model generated prediction
-        truth: ground truth label to compare against
-    Returns:
-        f1_score: values range from [0,1], with 1 indicating perfect accuracy
-    """
-    if labels:
-        mlb = MultiLabelBinarizer()
-        mlb.fit([labels])
+#     Args:
+#         prediction: model generated prediction
+#         truth: ground truth label to compare against
+#     Returns:
+#         f1_score: values range from [0,1], with 1 indicating perfect accuracy
+#     """
+#     if labels:
+#         mlb = MultiLabelBinarizer()
+#         mlb.fit([labels])
 
-        return f1_score(
-            mlb.transform([x.split(sep) for x in truth]),
-            mlb.transform([x.split(sep) for x in prediction]),
-            average=average,
-            zero_division=0,
-        )
-    else:
-        truth = [normalize_text(t).split(sep) for t in truth]
-        prediction = [normalize_text(p).split(sep) for p in prediction]
+#         return f1_score(
+#             mlb.transform([x.split(sep) for x in truth]),
+#             mlb.transform([x.split(sep) for x in prediction]),
+#             average=average,
+#             zero_division=0,
+#         )
+#     else:
+#         truth = [normalize_text(t).split(sep) for t in truth]
+#         prediction = [normalize_text(p).split(sep) for p in prediction]
 
-        tp_pairs = zip(truth, prediction)
+#         tp_pairs = zip(truth, prediction)
 
-        f1_scores = []
-        for truth_tokens, pred_tokens in tp_pairs:
-            # if either the prediction or the truth is no-answer then f1 = 1 if they agree, 0 otherwise
-            if len(truth_tokens) == 0 or len(pred_tokens) == 0:
-                f1_scores.append(int(truth_tokens == pred_tokens))
-                continue
+#         f1_scores = []
+#         for truth_tokens, pred_tokens in tp_pairs:
+#             # if either the prediction or the truth is no-answer then f1 = 1 if they agree, 0 otherwise
+#             if len(truth_tokens) == 0 or len(pred_tokens) == 0:
+#                 f1_scores.append(int(truth_tokens == pred_tokens))
+#                 continue
 
-            common_tokens = set(truth_tokens) & set(pred_tokens)
+#             common_tokens = set(truth_tokens) & set(pred_tokens)
 
-            # if there are no common tokens then f1 = 0
-            if len(common_tokens) == 0:
-                f1_scores.append(0)
-                continue
+#             # if there are no common tokens then f1 = 0
+#             if len(common_tokens) == 0:
+#                 f1_scores.append(0)
+#                 continue
 
-            rec = len(common_tokens) / len(truth_tokens)
-            prec = len(common_tokens) / len(pred_tokens)
+#             rec = len(common_tokens) / len(truth_tokens)
+#             prec = len(common_tokens) / len(pred_tokens)
 
-            f1_scores.append(2 * (prec * rec) / (prec + rec))
+#             f1_scores.append(2 * (prec * rec) / (prec + rec))
 
-        return sum(f1_scores) / len(f1_scores)
+#         return sum(f1_scores) / len(f1_scores)
 
 
 def filter_unlabeled_examples(gt_labels: List[str], llm_labels: List[LLMAnnotation]):

--- a/src/autolabel/tasks/utils.py
+++ b/src/autolabel/tasks/utils.py
@@ -27,63 +27,6 @@ def normalize_text(s: str) -> str:
     return white_space_fix(remove_articles(remove_punc(lower(s))))
 
 
-# def compute_f1(
-#     truth: List,
-#     prediction: List,
-#     average: str = "micro",
-#     labels: List[str] = None,
-#     sep: str = None,
-# ) -> float:
-#     """
-#     Compute f1 scores based on given ground truth labels.
-
-#     If labels are provided, uses sklearn to binarize the labels and compute f1 scores.
-#     Otherwise, uses bag of words approach to compute f1 scores.
-
-#     Args:
-#         prediction: model generated prediction
-#         truth: ground truth label to compare against
-#     Returns:
-#         f1_score: values range from [0,1], with 1 indicating perfect accuracy
-#     """
-#     if labels:
-#         mlb = MultiLabelBinarizer()
-#         mlb.fit([labels])
-
-#         return f1_score(
-#             mlb.transform([x.split(sep) for x in truth]),
-#             mlb.transform([x.split(sep) for x in prediction]),
-#             average=average,
-#             zero_division=0,
-#         )
-#     else:
-#         truth = [normalize_text(t).split(sep) for t in truth]
-#         prediction = [normalize_text(p).split(sep) for p in prediction]
-
-#         tp_pairs = zip(truth, prediction)
-
-#         f1_scores = []
-#         for truth_tokens, pred_tokens in tp_pairs:
-#             # if either the prediction or the truth is no-answer then f1 = 1 if they agree, 0 otherwise
-#             if len(truth_tokens) == 0 or len(pred_tokens) == 0:
-#                 f1_scores.append(int(truth_tokens == pred_tokens))
-#                 continue
-
-#             common_tokens = set(truth_tokens) & set(pred_tokens)
-
-#             # if there are no common tokens then f1 = 0
-#             if len(common_tokens) == 0:
-#                 f1_scores.append(0)
-#                 continue
-
-#             rec = len(common_tokens) / len(truth_tokens)
-#             prec = len(common_tokens) / len(pred_tokens)
-
-#             f1_scores.append(2 * (prec * rec) / (prec + rec))
-
-#         return sum(f1_scores) / len(f1_scores)
-
-
 def filter_unlabeled_examples(gt_labels: List[str], llm_labels: List[LLMAnnotation]):
     """Filter out unlabeled examples from the ground truth and LLM generated labels.
     This is done by checking the ground truth labels which have nan values.

--- a/src/autolabel/utils.py
+++ b/src/autolabel/utils.py
@@ -3,6 +3,8 @@ import os
 import json
 import logging
 from string import Formatter
+import re
+import string
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
 import shutil
 
@@ -293,3 +295,23 @@ def get_data(dataset_name: str, force: bool = False):
         download(test_url)
     except Exception as e:
         logger.error(f"Error downloading dataset: {e}")
+
+
+def normalize_text(s: str) -> str:
+    """Removing articles and punctuation, and standardizing whitespace are all typical text processing steps."""
+
+    def remove_articles(text):
+        regex = re.compile(r"\b(a|an|the)\b", re.UNICODE)
+        return re.sub(regex, " ", text)
+
+    def white_space_fix(text):
+        return " ".join(text.split())
+
+    def remove_punc(text):
+        exclude = set(string.punctuation)
+        return "".join(ch for ch in text if ch not in exclude)
+
+    def lower(text):
+        return text.lower()
+
+    return white_space_fix(remove_articles(remove_punc(lower(s))))

--- a/src/autolabel/utils.py
+++ b/src/autolabel/utils.py
@@ -36,6 +36,7 @@ EXAMPLE_DATASETS = [
     "sciq",
     "conll2003",
     "movie_reviews",
+    "twitter_emotion_detection",
 ]
 
 NO_SEED_DATASET = [

--- a/tests/unit/llm_test.py
+++ b/tests/unit/llm_test.py
@@ -31,7 +31,11 @@ def test_anthropic_label(mocker):
     )
     x = model.label(prompts)
     assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
+<<<<<<< HEAD
     assert sum(x.costs) == approx(0.00010944, rel=1e-3)
+=======
+    assert x.cost == approx(0.00010944, rel=1e-3)
+>>>>>>> e873409 (Fix llm tests)
 
 
 def test_anthropic_get_cost():
@@ -118,7 +122,11 @@ def test_gpt4_label(mocker):
     )
     x = model.label(prompts)
     assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
+<<<<<<< HEAD
     assert sum(x.costs) == approx(0.00023999, rel=1e-3)
+=======
+    assert x.cost == approx(0.00023999, rel=1e-3)
+>>>>>>> e873409 (Fix llm tests)
 
 
 def test_gpt4_get_cost():
@@ -168,7 +176,11 @@ def test_palm_label(mocker):
     )
     x = model.label(prompts)
     assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
+<<<<<<< HEAD
     assert sum(x.costs) == approx(2.4e-05, rel=1e-3)
+=======
+    assert x.cost == approx(2.4e-05, rel=1e-3)
+>>>>>>> e873409 (Fix llm tests)
 
 
 def test_palm_get_cost(mocker):

--- a/tests/unit/llm_test.py
+++ b/tests/unit/llm_test.py
@@ -31,11 +31,7 @@ def test_anthropic_label(mocker):
     )
     x = model.label(prompts)
     assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
-<<<<<<< HEAD
     assert sum(x.costs) == approx(0.00010944, rel=1e-3)
-=======
-    assert x.cost == approx(0.00010944, rel=1e-3)
->>>>>>> e873409 (Fix llm tests)
 
 
 def test_anthropic_get_cost():
@@ -122,11 +118,7 @@ def test_gpt4_label(mocker):
     )
     x = model.label(prompts)
     assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
-<<<<<<< HEAD
     assert sum(x.costs) == approx(0.00023999, rel=1e-3)
-=======
-    assert x.cost == approx(0.00023999, rel=1e-3)
->>>>>>> e873409 (Fix llm tests)
 
 
 def test_gpt4_get_cost():
@@ -176,11 +168,7 @@ def test_palm_label(mocker):
     )
     x = model.label(prompts)
     assert [i[0].text for i in x.generations] == ["Answers", "Answers"]
-<<<<<<< HEAD
     assert sum(x.costs) == approx(2.4e-05, rel=1e-3)
-=======
-    assert x.cost == approx(2.4e-05, rel=1e-3)
->>>>>>> e873409 (Fix llm tests)
 
 
 def test_palm_get_cost(mocker):

--- a/tests/unit/tasks_test.py
+++ b/tests/unit/tasks_test.py
@@ -8,7 +8,7 @@ from autolabel.tasks import (
     MultilabelClassificationTask,
 )
 from autolabel.configs import AutolabelConfig
-from autolabel.schema import LLMAnnotation, Metric
+from autolabel.schema import LLMAnnotation, MetricType, LabelingError, ErrorType
 
 from langchain.schema import Generation
 
@@ -89,34 +89,42 @@ def test_classification_eval():
         LLMAnnotation(
             successfully_labeled=True,
             label="label1",
+            error=None,
         ),
         LLMAnnotation(
             successfully_labeled=False,
             label=task.NULL_LABEL_TOKEN,
+            error=LabelingError(
+                error_type=ErrorType.LLM_PROVIDER_ERROR,
+                error_message="No label provided",
+            ),
         ),
         LLMAnnotation(
             successfully_labeled=True,
             label="label3-wrong",
+            error=None,
         ),
         LLMAnnotation(
             successfully_labeled=True,
             label="label4",
+            error=None,
         ),
         LLMAnnotation(
             successfully_labeled=True,
             label="label5-wrong",
+            error=None,
         ),
     ]
     gt_labels = ["label1", "label2", "label3", "label4", "label5"]
     eval = task.eval(llm_labels, gt_labels)
 
     for metric in eval:
-        if metric.metric_type == Metric.ACCURACY:
-            assert metric.value[0] == 0.5
-        elif metric.metric_type == Metric.COMPLETION_RATE:
-            assert metric.value[0] == 0.8
-        elif metric.metric_type == Metric.SUPPORT:
-            assert metric.value[0] == 4
+        if metric.name == MetricType.ACCURACY:
+            assert metric.value == 0.5
+        elif metric.name == MetricType.COMPLETION_RATE:
+            assert metric.value == 0.8
+        elif metric.name == MetricType.SUPPORT:
+            assert metric.value == 5
 
 
 def test_entity_matching_construct_prompt():
@@ -227,22 +235,30 @@ def test_entity_matching_eval():
         LLMAnnotation(
             successfully_labeled=True,
             label="duplicate",
+            error=None,
         ),
         LLMAnnotation(
             successfully_labeled=False,
             label=task.NULL_LABEL_TOKEN,
+            error=LabelingError(
+                error_type=ErrorType.LLM_PROVIDER_ERROR,
+                error_message="No label provided",
+            ),
         ),
         LLMAnnotation(
             successfully_labeled=True,
             label="not duplicate",
+            error=None,
         ),
         LLMAnnotation(
             successfully_labeled=True,
             label="not duplicate",
+            error=None,
         ),
         LLMAnnotation(
             successfully_labeled=True,
             label="duplicate",
+            error=None,
         ),
     ]
     gt_labels = [
@@ -255,12 +271,12 @@ def test_entity_matching_eval():
     eval = task.eval(llm_labels, gt_labels)
 
     for metric in eval:
-        if metric.metric_type == Metric.ACCURACY:
-            assert metric.value[0] == 0.75
-        elif metric.metric_type == Metric.COMPLETION_RATE:
-            assert metric.value[0] == 0.8
-        elif metric.metric_type == Metric.SUPPORT:
-            assert metric.value[0] == 4
+        if metric.name == MetricType.ACCURACY:
+            assert metric.value == 0.75
+        elif metric.name == MetricType.COMPLETION_RATE:
+            assert metric.value == 0.8
+        elif metric.name == MetricType.SUPPORT:
+            assert metric.value == 5
 
 
 def question_answering_construct_prompt():
@@ -329,22 +345,30 @@ def test_question_answering_eval():
         LLMAnnotation(
             successfully_labeled=True,
             label="Delhi",
+            error=None,
         ),
         LLMAnnotation(
             successfully_labeled=False,
             label=task.NULL_LABEL_TOKEN,
+            error=LabelingError(
+                error_type=ErrorType.LLM_PROVIDER_ERROR,
+                error_message="No label provided",
+            ),
         ),
         LLMAnnotation(
             successfully_labeled=True,
             label="Paris",
+            error=None,
         ),
         LLMAnnotation(
             successfully_labeled=True,
             label="Bangalore",
+            error=None,
         ),
         LLMAnnotation(
             successfully_labeled=True,
             label="Delhi",
+            error=None,
         ),
     ]
     gt_labels = [
@@ -357,12 +381,12 @@ def test_question_answering_eval():
     eval = task.eval(llm_labels, gt_labels)
 
     for metric in eval:
-        if metric.metric_type == Metric.ACCURACY:
-            assert metric.value[0] == 0.75
-        elif metric.metric_type == Metric.COMPLETION_RATE:
-            assert metric.value[0] == 0.8
-        elif metric.metric_type == Metric.SUPPORT:
-            assert metric.value[0] == 4
+        if metric.name == MetricType.ACCURACY:
+            assert metric.value == 0.75
+        elif metric.name == MetricType.COMPLETION_RATE:
+            assert metric.value == 0.8
+        elif metric.name == MetricType.SUPPORT:
+            assert metric.value == 5
 
 
 def test_classification_labels_not_in_labels_list():
@@ -445,22 +469,30 @@ def test_multilabel_classification_eval():
         LLMAnnotation(
             successfully_labeled=True,
             label="neutral",
+            error=None,
         ),
         LLMAnnotation(
             successfully_labeled=False,
             label=task.NULL_LABEL_TOKEN,
+            error=LabelingError(
+                error_type=ErrorType.LLM_PROVIDER_ERROR,
+                error_message="No label provided",
+            ),
         ),
         LLMAnnotation(
             successfully_labeled=True,
             label="sadness",
+            error=None,
         ),
         LLMAnnotation(
             successfully_labeled=True,
             label="anger, disgust",
+            error=None,
         ),
         LLMAnnotation(
             successfully_labeled=True,
             label="joy, love, trust",
+            error=None,
         ),
     ]
     gt_labels = [
@@ -473,13 +505,13 @@ def test_multilabel_classification_eval():
     eval = task.eval(llm_labels, gt_labels)
 
     for metric in eval:
-        if metric.metric_type == Metric.ACCURACY:
-            assert metric.value[0] == 0.25
-        elif metric.metric_type == Metric.F1_MACRO:
-            assert metric.value[0] == 0.25
-        elif metric.metric_type == Metric.F1_WEIGHTED:
-            assert metric.value[0] == 5 / 9
-        elif metric.metric_type == Metric.COMPLETION_RATE:
-            assert metric.value[0] == 0.8
-        elif metric.metric_type == Metric.SUPPORT:
-            assert metric.value[0] == 4
+        if metric.name == MetricType.ACCURACY:
+            assert metric.value == 0.25
+        elif metric.name == MetricType.F1_MACRO:
+            assert metric.value == 0.25
+        elif metric.name == MetricType.F1_WEIGHTED:
+            assert metric.value == 5 / 9
+        elif metric.name == MetricType.COMPLETION_RATE:
+            assert metric.value == 0.8
+        elif metric.name == MetricType.SUPPORT:
+            assert metric.value == 5


### PR DESCRIPTION
- This allows separation of metric calculation from all tasks
- Users can define new additional metrics as classes which can be run every time the model runs
- AUROC calculation now does not return thresholds
- Thresholding logic removed from all tasks - users can request the values at specific thresholds using the output object, or agent.report can show only the thresholds which the user should care about
- Allow specifying custom metrics