### PR TITLE
added logit bias for huggingface

### DIFF
--- a/src/autolabel/configs/config.py
+++ b/src/autolabel/configs/config.py
@@ -125,9 +125,9 @@ class AutolabelConfig(BaseConfig):
         """Returns true if the model is able to return a confidence score along with its predictions"""
         return self._model_config.get(self.COMPUTE_CONFIDENCE_KEY, False)
 
-    def logit_bias(self) -> bool:
-        """Returns true if the model is configured to use a logit bias"""
-        return self._model_config.get(self.LOGIT_BIAS_KEY, False)
+    def logit_bias(self) -> float:
+        """Returns the logit bias for the labels specified in the config"""
+        return self._model_config.get(self.LOGIT_BIAS_KEY, 0.0)
 
     # Embedding config
     def embedding_provider(self) -> str:

--- a/src/autolabel/configs/schema.py
+++ b/src/autolabel/configs/schema.py
@@ -68,7 +68,7 @@ schema = {
                 },
                 "name": {"type": "string"},
                 "compute_confidence": {"type": ["boolean", "null"]},
-                "logit_bias": {"type": ["boolean", "null"]},
+                "logit_bias": {"type": ["number", "null"]},
                 "params": {"type": ["object", "null"]},
             },
             "required": ["provider", "name"],


### PR DESCRIPTION
Added logit bias for `huggingface_pipeline` models which can be enabled by settings `logit_bias` to `True` in the model config (just like `openai`)