### PR TITLE
CLI Logit Bias and Model Params Fix

### DIFF
--- a/src/autolabel/cli/config.py
+++ b/src/autolabel/cli/config.py
@@ -186,7 +186,16 @@ def _create_model_config_wizard() -> Dict:
         model_param_value = Prompt.ask(
             f"Enter the value for {model_param}",
         )
-        model_params[model_param] = model_param_value
+        if model_param_value.lower() in ["true", "false"]:
+            model_params[model_param] = model_param_value.lower() == "true"
+        elif model_param_value.isdigit():
+            model_params[model_param] = int(model_param_value)
+        else:
+            try:
+                model_params[model_param] = float(model_param_value)
+            except ValueError:
+                model_params[model_param] = model_param_value
+
         model_param = Prompt.ask(
             "Enter a model parameter name (or leave blank to finish)",
             default=None,

--- a/src/autolabel/cli/config.py
+++ b/src/autolabel/cli/config.py
@@ -12,7 +12,6 @@ from autolabel.configs import AutolabelConfig as ALC
 from autolabel.configs.schema import schema
 from autolabel.schema import TaskType, FewShotAlgorithm, ModelProvider
 from autolabel.data_loaders import DatasetLoader
-from autolabel.models import ModelFactory
 from autolabel.tasks import TASK_TYPE_TO_IMPLEMENTATION
 
 from autolabel.cli.template import (
@@ -23,6 +22,19 @@ from autolabel.cli.template import (
 
 
 def _get_sub_config(key: str, **kwargs) -> Dict:
+    """Get a sub-configuration dictionary for the specified key.
+
+    This function processes the provided keyword arguments to extract specific configurations
+    for the given key and returns a dictionary containing the key's template configuration merged
+    with the relevant configuration values from the provided keyword arguments.
+
+    Args:
+        key (str): The key for which the sub-configuration is to be generated.
+        **kwargs: Keyword arguments containing configuration values with keys in the format "{key}_{property}".
+
+    Returns:
+        Dict: A dictionary containing the sub-configuration for the specified key.
+    """
     config = {}
     for p in schema["properties"][key]["properties"]:
         if f"{key}_{p}" in kwargs and kwargs[f"{key}_{p}"] is not None:
@@ -34,6 +46,15 @@ def _get_sub_config(key: str, **kwargs) -> Dict:
 
 
 def _get_labels_from_seed(df: pd.DataFrame, config: Dict) -> List[str]:
+    """Get the list of unique labels from the given DataFrame based on the task type specified in the configuration.
+
+    Args:
+        df (pd.DataFrame): The DataFrame containing the dataset.
+        config (Dict): Configuration settings for the labeling task.
+
+    Returns:
+        List[str]: A list of unique labels extracted from the DataFrame based on the task type.
+    """
     if config[ALC.TASK_TYPE_KEY] in [
         TaskType.CLASSIFICATION.value,
         TaskType.ENTITY_MATCHING.value,
@@ -66,6 +87,22 @@ def init(
     guess_labels: bool = False,
     **kwargs,
 ):
+    """Initialize and create a configuration for the Autolabel task.
+
+    This function takes various arguments to set up the configuration for the Autolabel task,
+    including the task name, task type, dataset configuration, model configuration, prompt configuration,
+    and more. If guess_labels is True and a seed file is provided, it attempts to infer labels from the seed data.
+
+    Args:
+        seed (Optional[str]): Path to the seed file containing the dataset (default is None).
+        task_name (Optional[str]): Name of the task (default is None, which uses a template name).
+        task_type (Optional[str]): Type of the task (default is None, which uses a template type).
+        guess_labels (bool): Whether to attempt inferring labels from the seed data (default is False).
+        **kwargs: Additional keyword arguments for configuring the dataset, model, and prompt.
+
+    Returns:
+        None: The function writes the generated configuration to a JSON file.
+    """
     if not task_name:
         task_name = TEMPLATE_CONFIG[ALC.TASK_NAME_KEY]
     try:
@@ -111,6 +148,19 @@ def init(
 def _create_dataset_config_wizard(
     task_type: TaskType, seed: Optional[str] = None
 ) -> Dict:
+    """Create a dataset configuration based on user input and task type.
+
+    This function interacts with the user through prompts to set up the dataset configuration
+    for the Autolabel task. The user provides details like delimiter, label column, explanation column,
+    and label separator (for multi-label classification) to create the dataset configuration dictionary.
+
+    Args:
+        task_type (TaskType): Type of the task, such as classification or multi-label classification.
+        seed (Optional[str]): Path to the seed file containing the dataset (default is None).
+
+    Returns:
+        Dict: A dictionary containing the dataset configuration for the Autolabel task.
+    """
     print("[bold]Dataset Configuration[/bold]")
     dataset_config = {}
 
@@ -167,6 +217,15 @@ def _create_dataset_config_wizard(
 
 
 def _create_model_config_wizard() -> Dict:
+    """Create a model configuration through interactive prompts.
+
+    This function guides the user through interactive prompts to set up the model configuration
+    for the Autolabel task. The user provides details such as the model provider, model name,
+    model parameters, and whether the model should compute confidence or use logit bias.
+
+    Returns:
+        Dict: A dictionary containing the model configuration for the Autolabel task.
+    """
     print("[bold]Model Configuration[/bold]")
     model_config = {}
 
@@ -220,6 +279,19 @@ def _create_model_config_wizard() -> Dict:
 
 
 def _create_prompt_config_wizard(config: Dict, seed: Optional[str] = None) -> Dict:
+    """Create a prompt configuration through interactive prompts.
+
+    This function guides the user through interactive prompts to set up the prompt configuration
+    for the Autolabel task based on the provided dataset and task type configuration.
+    The user provides details such as task guidelines, valid labels, example template, and few-shot examples.
+
+    Args:
+        config (Dict): Configuration settings for the Autolabel task.
+        seed (Optional[str]): Path to the seed file containing the dataset (default is None).
+
+    Returns:
+        Dict: A dictionary containing the prompt configuration for the Autolabel task.
+    """
     print("[bold]Prompt Configuration[/bold]")
     prompt_config = {}
 
@@ -336,8 +408,20 @@ def _create_prompt_config_wizard(config: Dict, seed: Optional[str] = None) -> Di
 def create_config_wizard(
     seed: Optional[str] = None,
     **kwargs,
-):
-    """Create a new task [bold]config[/bold] file"""
+) -> None:
+    """Create a configuration wizard for the Autolabel task.
+
+    This function guides the user through interactive prompts to set up the complete configuration
+    for the Autolabel task, including task name, task type, dataset configuration, model configuration,
+    and prompt configuration. It validates the configuration and writes it to a JSON file.
+
+    Args:
+        seed (Optional[str]): Path to the seed file containing the dataset (default is None).
+        **kwargs: Additional keyword arguments for configuring the dataset, model, and prompt.
+
+    Returns:
+        None: The function writes the generated configuration to a JSON file.
+    """
     config = {}
     task_name = Prompt.ask("Enter the task name")
     config[ALC.TASK_NAME_KEY] = task_name


### PR DESCRIPTION
Recently turned logit bias into a float (instead of a boolean) in #495 so the CLI must be updated accordingly. Additionally, previously the CLI only took in strings as model param values. This PR changes that so the CLI can automatically detect booleans, integers, and floats, defaulting to strings when it satisfies none of the others.