### PR TITLE
Accept config in LabelingAgent

### DIFF
--- a/src/autolabel/__init__.py
+++ b/src/autolabel/__init__.py
@@ -2,6 +2,8 @@ from importlib import metadata
 
 from .labeler import LabelingAgent
 from .utils import get_data
+from .dataset import AutolabelDataset
+from .configs import AutolabelConfig
 
 try:
     __version__ = metadata.version("refuel-autolabel")

--- a/src/autolabel/__init__.py
+++ b/src/autolabel/__init__.py
@@ -2,8 +2,6 @@ from importlib import metadata
 
 from .labeler import LabelingAgent
 from .utils import get_data
-from .dataset import AutolabelDataset
-from .configs import AutolabelConfig
 
 try:
     __version__ = metadata.version("refuel-autolabel")

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -43,13 +43,13 @@ class LabelingAgent:
 
     def __init__(
         self,
-        config: Union[str, Dict],
+        config: AutolabelConfig,
         cache: Optional[bool] = True,
     ) -> None:
         self.db = StateManager()
         self.cache = SQLAlchemyCache() if cache else None
 
-        self.config = AutolabelConfig(config)
+        self.config = config
         self.task = TaskFactory.from_config(self.config)
         self.llm: BaseModel = ModelFactory.from_config(self.config, cache=self.cache)
         self.confidence = ConfidenceCalculator(

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -43,13 +43,15 @@ class LabelingAgent:
 
     def __init__(
         self,
-        config: AutolabelConfig,
+        config: Union[AutolabelConfig, str, dict],
         cache: Optional[bool] = True,
     ) -> None:
         self.db = StateManager()
         self.cache = SQLAlchemyCache() if cache else None
 
-        self.config = config
+        self.config = (
+            config if isinstance(config, AutolabelConfig) else AutolabelConfig(config)
+        )
         self.task = TaskFactory.from_config(self.config)
         self.llm: BaseModel = ModelFactory.from_config(self.config, cache=self.cache)
         self.confidence = ConfidenceCalculator(

--- a/tests/unit/dummy_test.py
+++ b/tests/unit/dummy_test.py
@@ -1,13 +1,18 @@
 from autolabel import LabelingAgent
+from autolabel.configs import AutolabelConfig
 
 
 def test_labeling_agent_config():
-    agent = LabelingAgent(config="tests/assets/banking/config_banking.json")
+    agent = LabelingAgent(
+        config=AutolabelConfig("tests/assets/banking/config_banking.json")
+    )
     assert agent.config != None
 
 
 def test_mock_example(mocker):
-    agent = LabelingAgent(config="tests/assets/banking/config_banking.json")
+    agent = LabelingAgent(
+        config=AutolabelConfig("tests/assets/banking/config_banking.json")
+    )
     mocker.patch("autolabel.labeler.LabelingAgent.run", return_value=True)
     res = agent.run("tests/assets/banking/banking_test.csv")
     assert res == True

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,6 +4,7 @@ import pytest
 from jsonschema import validate, exceptions
 from autolabel import LabelingAgent
 from autolabel.configs.schema import schema
+from autolabel.configs import AutolabelConfig
 
 
 CONFIG_SAMPLE_DICT = {
@@ -25,19 +26,25 @@ CONFIG_SAMPLE_DICT = {
 
 def test_config():
     """Test configurations"""
-    agent0 = LabelingAgent(config="tests/assets/banking/config_banking.json")
+    agent0 = LabelingAgent(
+        config=AutolabelConfig("tests/assets/banking/config_banking.json")
+    )
     config0 = agent0.config
     assert config0.label_column() == "label"
     assert config0.task_type() == "classification"
     assert config0.delimiter() == ","
 
-    agent1 = LabelingAgent(config="tests/assets/conll2003/config_conll2003.json")
+    agent1 = LabelingAgent(
+        config=AutolabelConfig("tests/assets/conll2003/config_conll2003.json")
+    )
     config1 = agent1.config
     assert config1.label_column() == "CategorizedLabels"
     assert config1.text_column() == "example"
     assert config1.task_type() == "named_entity_recognition"
 
-    agent2 = LabelingAgent(config="tests/assets/squad_v2/config_squad_v2.json")
+    agent2 = LabelingAgent(
+        config=AutolabelConfig("tests/assets/squad_v2/config_squad_v2.json")
+    )
     config2 = agent2.config
     assert config2.label_column() == "answer"
     assert config2.task_type() == "question_answering"

--- a/tests/unit/test_data_loading.py
+++ b/tests/unit/test_data_loading.py
@@ -1,6 +1,7 @@
 from autolabel import LabelingAgent
 from autolabel.dataset import AutolabelDataset
 from pandas import DataFrame
+from autolabel.configs import AutolabelConfig
 
 csv_path = "tests/assets/banking/test.csv"
 jsonl_path = "tests/assets/banking/test.jsonl"
@@ -8,7 +9,7 @@ config_path = "tests/assets/banking/config_banking.json"
 
 
 def test_read_csv():
-    agent = LabelingAgent(config=config_path)
+    agent = LabelingAgent(config=AutolabelConfig(config_path))
     dataset = AutolabelDataset(csv_path, agent.config)
     # test return types
     assert isinstance(dataset, AutolabelDataset)
@@ -26,7 +27,7 @@ def test_read_csv():
 
 
 def test_read_dataframe():
-    agent = LabelingAgent(config=config_path)
+    agent = LabelingAgent(config=AutolabelConfig(config_path))
     df = AutolabelDataset(csv_path, agent.config).df
     dataset = AutolabelDataset(df, agent.config)
     # test return types
@@ -47,7 +48,7 @@ def test_read_dataframe():
 
 
 def test_read_jsonl():
-    agent = LabelingAgent(config=config_path)
+    agent = LabelingAgent(config=AutolabelConfig(config_path))
     dataset = AutolabelDataset(jsonl_path, agent.config)
     # test return types
     assert isinstance(dataset, AutolabelDataset)


### PR DESCRIPTION
Currently we can pass a dict or string to the Labeling Agent.

This PR will change the LabelingAgent to accept an AutolabelConfig object as an input (to be consistent with the input to the dataset object)

```
from autolabel import LabelingAgent, AutolabelConfig, AutolabelDataset
config = AutolabelConfig('config.json')
dataset = AutolabelDataset('test.csv', config)
agent = LabelingAgent(config)
```