### PR TITLE
fixes to cli documentation like lists and others

### DIFF
--- a/docs/guide/resources/CLI.md
+++ b/docs/guide/resources/CLI.md
@@ -4,21 +4,27 @@ The Autolabel CLI was created to make the [config](https://docs.refuel.ai/guide/
 autolabel config
 ```
 
-**Walkthrough: Creating a Config for Civil Comments**
+### **Walkthrough: Creating a Config for Civil Comments**
 
-1. The first step is to run the `autolabel` command with the `config` argument:
+<ol>
+<li>
+The first step is to run the <code>autolabel</code> command with the <code>config</code> argument:
 
 ```bash
 autolabel config
 ```
 
-2. The program will prompt you to enter the task name.
+</li>
+<li>
+The program will prompt you to enter the task name.
 
 ```
 Enter the task name: ToxicCommentClassification
 ```
 
-3. Next, you need to choose the task type from the provided options.:
+</li>
+<li>
+Next, you need to choose the task type from the provided options.:
 
 ```
 Choose a task type
@@ -29,7 +35,9 @@ Choose a task type
   multilabel_classification
 ```
 
-4. Now, the program will ask for dataset configuration details. You need to specify the delimiter used in your dataset, the label column name, and an optional explanation column name:
+</li>
+<li>
+Now, the program will ask for dataset configuration details. You need to specify the delimiter used in your dataset, the label column name, and an optional explanation column name:
 
 ```
 Dataset Configuration
@@ -38,9 +46,11 @@ Enter the label column name: label
 Enter the explanation column name (optional):
 ```
 
-*Anything surrounded by parenthesis at the end of a prompt will be used as the default value if you don't input anything. Make sure to change this if it does not line up with your task.*
+<em>Anything surrounded by parenthesis at the end of a prompt will be used as the default value if you don't input anything. Make sure to change this if it does not line up with your task.</em>
 
-5. The program will then ask for model configuration. You will need to specify the model provider from the options. Next, enter the model name, optional model parameters, whether the model should compute confidence, and the strength of the logit bias:
+</li>
+<li>
+The program will then ask for model configuration. You will need to specify the model provider from the options. Next, enter the model name, optional model parameters, whether the model should compute confidence, and the strength of the logit bias:
 
 ```
 Model Configuration
@@ -57,7 +67,9 @@ Should the model compute confidence? [y/n] (n):
 What is the strength of logit bias? (0.0): 100
 ```
 
-6. Next, you will configure the task prompt. First, enter the task guidelines. In the task guidelines, `{num_labels}` and `{labels}` will be replaced by the number of labels and the labels list respectively. Next, specify the labels. Then, write the example template with placeholders for the column names you want to use in the prompt. You can also add an output guideline and format if needed. Lastly, you can choose whether to use a chain of thought:
+</li>
+<li>
+Next, you will configure the task prompt. First, enter the task guidelines. In the task guidelines, <code>{num_labels}</code> and <code>{labels}</code> will be replaced by the number of labels and the labels list respectively. Next, specify the labels. Then, write the example template with placeholders for the column names you want to use in the prompt. You can also add an output guideline and format if needed. Lastly, you can choose whether to use a chain of thought:
 
 ```
 Prompt Configuration
@@ -75,7 +87,9 @@ Enter the output format (optional):
 Should the prompt use a chain of thought? [y/n] (n):
 ```
 
-7. The program will then display the configuration that you have provided as a python dictionary:
+</li>
+<li>
+The program will then display the configuration that you have provided as a python dictionary:
 
 ```python
 {
@@ -92,15 +106,20 @@ Should the prompt use a chain of thought? [y/n] (n):
 }
 ```
 
-8. Finally, the program will write the configuration to a file named "{your_task_name}_config.json".
+</li>
+<li>
+Finally, the program will write the configuration to a file named "{your_task_name}_config.json".
 
 ```
 Writing config to ToxicCommentClassification_config.json
 ```
 
+</li>
+</ol>
 That's it! You have successfully created a config for a task using the CLI program. The generated configuration file can now be used for any labeling runs with autolabel!
 
 ### Providing a seed file
+
 You can provide a seed file to the CLI to help it generate the config file. Providing a seed file to the CLI allows it to automatically provide drop-down menus for column name inputs, detect labels that are already present in the seed file, and fill the few shot examples by row number in the seed file. To do this, simply run the following command:
 
 ```bash
@@ -147,6 +166,7 @@ Enter the number of few shot examples to use (4):
 As you can see, the CLI automatically detected the labels in the seed file and used them to generate the labels list. It also automatically filled the few shot examples with the examples from the seed file after letting the user choose the rows to use.
 
 ### Specifying Model Parameters
+
 To specify model parameters, you can simply enter the parameter name and value when prompted. For example, if you wanted to specify the `temperature` parameter for the `gpt-3.5-turbo` model, you would run the following command:
 
 ```
@@ -155,6 +175,7 @@ Enter the value for max_tokens: 0.5
 ```
 
 ### Providing Few Shot Examples
+
 To provide few shot examples, you can simply input the example when prompted (after entering the example template). The CLI will go through the example template and ask for any values specified in that. For example, if you template is `Example: {example}\nLabel: {label}`, you could add a few shot example as shown below:
 
 ```
@@ -180,34 +201,35 @@ Enter the number of few shot examples to use (4):
 Since we only added 4 examples, we chose the `fixed` few shot selection algorithm and left the number of few shot examples to use at 4 since we want to use all of them in every prompt.
 
 ## The `init` command
+
 If you would prefer to edit a json file directly, you can use the `init` command to generate a config file for you. To do this, simply run the following command:
 
 ```bash
 autolabel init
 ```
 
-By default, this will create a config file that looks like the one below: 
+By default, this will create a config file that looks like the one below:
 
 ```json
 {
-    "task_name": "[TODO] Enter task name",
-    "task_type": "[TODO] Enter task type",
-    "dataset": {
-        "delimiter": "[TODO] Enter delimiter",
-        "label_column": "[TODO] Enter label column name"
-    },
-    "model": {
-        "provider": "openai",
-        "name": "gpt-3.5-turbo",
-        "params": {}
-    },
-    "prompt": {
-        "task_guidelines": "[TODO] Enter task guidelines",
-        "example_template": "[TODO] Enter example template",
-        "few_shot_examples": "[TODO] Enter few shot examples",
-        "few_shot_selection": "[TODO] Enter few shot selection",
-        "few_shot_num": "[TODO] Enter few shot num"
-    }
+  "task_name": "[TODO] Enter task name",
+  "task_type": "[TODO] Enter task type",
+  "dataset": {
+    "delimiter": "[TODO] Enter delimiter",
+    "label_column": "[TODO] Enter label column name"
+  },
+  "model": {
+    "provider": "openai",
+    "name": "gpt-3.5-turbo",
+    "params": {}
+  },
+  "prompt": {
+    "task_guidelines": "[TODO] Enter task guidelines",
+    "example_template": "[TODO] Enter example template",
+    "few_shot_examples": "[TODO] Enter few shot examples",
+    "few_shot_selection": "[TODO] Enter few shot selection",
+    "few_shot_num": "[TODO] Enter few shot num"
+  }
 }
 ```
 
@@ -221,32 +243,30 @@ Resulting in the following config file for the civil comments dataset:
 
 ```json
 {
-    "task_name": "ToxicCommentClassification",
-    "task_type": "classification",
-    "dataset": {
-        "delimiter": ",",
-        "label_column": "label"
-    },
-    "model": {
-        "provider": "openai",
-        "name": "gpt-3.5-turbo",
-        "params": {}
-    },
-    "prompt": {
-        "task_guidelines": "You are an expert at identifying toxic comments.",
-        "example_template": "Example: {example}\nLabel: {label}",
-        "few_shot_examples": "seed.csv",
-        "few_shot_selection": "semantic_similarity",
-        "few_shot_num": 5,
-        "labels": [
-            "not toxic",
-            "toxic"
-        ]
-    }
+  "task_name": "ToxicCommentClassification",
+  "task_type": "classification",
+  "dataset": {
+    "delimiter": ",",
+    "label_column": "label"
+  },
+  "model": {
+    "provider": "openai",
+    "name": "gpt-3.5-turbo",
+    "params": {}
+  },
+  "prompt": {
+    "task_guidelines": "You are an expert at identifying toxic comments.",
+    "example_template": "Example: {example}\nLabel: {label}",
+    "few_shot_examples": "seed.csv",
+    "few_shot_selection": "semantic_similarity",
+    "few_shot_num": 5,
+    "labels": ["not toxic", "toxic"]
+  }
 }
 ```
 
 ## The `plan` command
+
 The `plan` command works identically to running `LabelingAgent({config}).plan({dataset})` in python. To use it, simply run the following command:
 
 ```bash
@@ -254,6 +274,7 @@ autolabel plan <path-to-dataset> <path-to-config>
 ```
 
 ## The `run` command
+
 The `run` command works identically to running `LabelingAgent({config}).run({dataset})` in python. To use it, simply run the following command:
 
 ```bash
@@ -261,4 +282,5 @@ autolabel run <path-to-dataset> <path-to-config>
 ```
 
 ## Help
+
 If any of the commands are unclear, you can run `autolabel --help` to see the help menu or `autolabel <command> --help` to see the help menu for a specific command.


### PR DESCRIPTION
The list was showing up as "1. ... 1. ... 1. ..." instead of "1. ... 2. ... 3. ..." which fixes resulted in fixing some other formatting errors as well