### PR TITLE
fix bugs for kill signal and indexing

### DIFF
--- a/src/autolabel/cli/config.py
+++ b/src/autolabel/cli/config.py
@@ -307,9 +307,7 @@ def _create_prompt_config_wizard(config: Dict, seed: Optional[str] = None) -> Di
     ).replace("\\n", "\n")
 
     seed_labels = (
-        dataset.df[unvalidated_config.label_column()].unique().tolist()
-        if seed
-        else []
+        dataset.df[unvalidated_config.label_column()].unique().tolist() if seed else []
     )
     if seed_labels and Confirm.ask(
         f"Detected {len(seed_labels)} unique labels in seed dataset. Use these labels?"

--- a/src/autolabel/cli/config.py
+++ b/src/autolabel/cli/config.py
@@ -8,10 +8,10 @@ from simple_term_menu import TerminalMenu
 
 import pandas as pd
 
+from autolabel import AutolabelDataset
 from autolabel.configs import AutolabelConfig as ALC
 from autolabel.configs.schema import schema
 from autolabel.schema import TaskType, FewShotAlgorithm, ModelProvider
-from autolabel.data_loaders import DatasetLoader
 from autolabel.tasks import TASK_TYPE_TO_IMPLEMENTATION
 
 from autolabel.cli.template import (
@@ -297,7 +297,7 @@ def _create_prompt_config_wizard(config: Dict, seed: Optional[str] = None) -> Di
 
     if seed:
         unvalidated_config = ALC(config, validate=False)
-        dataset_loader = DatasetLoader(seed, unvalidated_config, validate=False)
+        dataset = AutolabelDataset(seed, unvalidated_config, validate=False)
 
     prompt_config[ALC.TASK_GUIDELINE_KEY] = Prompt.ask(
         "Enter the task guidelines",
@@ -307,7 +307,7 @@ def _create_prompt_config_wizard(config: Dict, seed: Optional[str] = None) -> Di
     ).replace("\\n", "\n")
 
     seed_labels = (
-        dataset_loader.dat[unvalidated_config.label_column()].unique().tolist()
+        dataset.df[unvalidated_config.label_column()].unique().tolist()
         if seed
         else []
     )
@@ -358,7 +358,7 @@ def _create_prompt_config_wizard(config: Dict, seed: Optional[str] = None) -> Di
         while example:
             example_dict = {}
             if seed and example.isdigit():
-                example_dict = dataset_loader.dat.iloc[int(example)].to_dict()
+                example_dict = dataset.df.iloc[int(example)].to_dict()
                 print(example_dict)
             else:
                 example_dict[example_template_variables[0]] = example

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -61,7 +61,7 @@ class LabelingAgent:
         self.db = StateManager() if self.create_task else None
         self.generation_cache = SQLAlchemyGenerationCache() if cache else None
         self.transform_cache = SQLAlchemyTransformCache() if cache else None
-        self.console = Console() if console_output else None
+        self.console = Console() if console_output else Console(quiet=True)
 
         self.config = (
             config if isinstance(config, AutolabelConfig) else AutolabelConfig(config)
@@ -170,17 +170,12 @@ class LabelingAgent:
 
         indices = range(current_index, len(dataset.inputs))
 
-        if self.console:
-            tracker = track_with_stats(
-                indices,
-                postfix_dict,
-                total=len(dataset.inputs) - current_index,
-                console=self.console,
-            )
-        else:
-            tracker = indices
-
-        for current_index in tracker:
+        for current_index in track_with_stats(
+            indices,
+            postfix_dict,
+            total=len(dataset.inputs) - current_index,
+            console=self.console,
+        ):
             chunk = dataset.inputs[current_index]
 
             if self.example_selector:
@@ -271,12 +266,11 @@ class LabelingAgent:
                 elif m.show_running:
                     table[m.name] = m.value
                 else:
-                    print(f"{m.name}:\n{m.value}")
+                    self.console.print(f"{m.name}:\n{m.value}")
 
         # print cost
-        if self.console:
-            print(f"Actual Cost: {maybe_round(cost)}")
-            print_table(table, console=self.console, default_style=METRIC_TABLE_STYLE)
+        self.console.print(f"Actual Cost: {maybe_round(cost)}")
+        print_table(table, console=self.console, default_style=METRIC_TABLE_STYLE)
 
         dataset.process_labels(llm_labels, eval_result)
         # Only save to csv if output_name is provided or dataset is a string
@@ -337,16 +331,11 @@ class LabelingAgent:
 
         input_limit = min(len(dataset.inputs), 100)
 
-        if self.console:
-            tracker = track(
-                dataset.inputs[:input_limit],
-                description="Generating Prompts...",
-                console=self.console,
-            )
-        else:
-            tracker = dataset.inputs[:input_limit]
-
-        for input_i in tracker:
+        for input_i in track(
+            dataset.inputs[:input_limit],
+            description="Generating Prompts...",
+            console=self.console,
+        ):
             # TODO: Check if this needs to use the example selector
             if self.example_selector:
                 examples = self.example_selector.select_examples(input_i)
@@ -367,13 +356,12 @@ class LabelingAgent:
         }
         table = {"parameter": list(table.keys()), "value": list(table.values())}
 
-        if self.console:
-            print_table(
-                table, show_header=False, console=self.console, styles=COST_TABLE_STYLES
-            )
-            self.console.rule("Prompt Example")
-            print(f"{prompt_list[0]}")
-            self.console.rule()
+        print_table(
+            table, show_header=False, console=self.console, styles=COST_TABLE_STYLES
+        )
+        self.console.rule("Prompt Example")
+        self.console.print(f"{prompt_list[0]}")
+        self.console.rule()
 
     async def async_run_transform(
         self, transform: BaseTransform, dataset: AutolabelDataset
@@ -382,15 +370,11 @@ class LabelingAgent:
             transform.apply(input_dict) for input_dict in dataset.inputs
         ]
 
-        if self.console:
-            outputs = await gather_async_tasks_with_progress(
-                transform_outputs,
-                description=f"Running transform {transform.name()}...",
-                console=self.console,
-            )
-        else:
-            outputs = await asyncio.gather(*transform_outputs)
-
+        outputs = await gather_async_tasks_with_progress(
+            transform_outputs,
+            description=f"Running transform {transform.name()}...",
+            console=self.console,
+        )
         output_df = pd.DataFrame.from_records(outputs)
         final_df = pd.concat([dataset.df, output_df], axis=1)
         dataset = AutolabelDataset(final_df, self.config)
@@ -421,10 +405,12 @@ class LabelingAgent:
             csv_file_name: path to the dataset we wish to label (only used if user chooses to restart the task)
             gt_labels: If ground truth labels are provided, performance metrics will be displayed, such as label accuracy
         """
-        pprint(f"There is an existing task with following details: {task_run}")
+        self.console.print(
+            f"There is an existing task with following details: {task_run}"
+        )
         llm_labels = self.get_all_annotations()
         if gt_labels and len(llm_labels) > 0:
-            pprint("Evaluating the existing task...")
+            self.console.print("Evaluating the existing task...")
             gt_labels = gt_labels[: len(llm_labels)]
             eval_result = self.task.eval(
                 llm_labels, gt_labels, additional_metrics=additional_metrics
@@ -436,16 +422,13 @@ class LabelingAgent:
                 elif m.show_running:
                     table[m.name] = m.value
                 else:
-                    print(f"{m.name}:\n{m.value}")
+                    self.console.print(f"{m.name}:\n{m.value}")
 
-            if self.console:
-                print_table(
-                    table, console=self.console, default_style=METRIC_TABLE_STYLE
-                )
-        pprint(f"{task_run.current_index} examples labeled so far.")
+            print_table(table, console=self.console, default_style=METRIC_TABLE_STYLE)
+        self.console.print(f"{task_run.current_index} examples labeled so far.")
         if not Confirm.ask("Do you want to resume the task?"):
             TaskRunModel.delete_by_id(self.db.session, task_run.id)
-            pprint("Deleted the existing task and starting a new one...")
+            self.console.print("Deleted the existing task and starting a new one...")
             task_run = self.db.create_task_run(
                 csv_file_name, self.task_object.id, self.dataset_obj.id
             )
@@ -497,16 +480,11 @@ class LabelingAgent:
                 "The explanation column needs to be specified in the dataset config."
             )
 
-        if self.console:
-            tracker = track(
-                seed_examples,
-                description="Generating explanations",
-                console=self.console,
-            )
-        else:
-            tracker = seed_examples
-
-        for seed_example in tracker:
+        for seed_example in track(
+            seed_examples,
+            description="Generating explanations",
+            console=self.console,
+        ):
             explanation_prompt = self.task.get_explanation_prompt(seed_example)
             explanation = self.llm.label([explanation_prompt])
             explanation = explanation.generations[0][0].text
@@ -521,19 +499,25 @@ class LabelingAgent:
     def generate_synthetic_dataset(self) -> AutolabelDataset:
         columns = get_format_variables(self.config.example_template())
         df = pd.DataFrame(columns=columns)
-        for label in self.config.labels_list():
+        for label in track(
+            self.config.labels_list(),
+            description="Generating dataset",
+            console=self.console,
+        ):
             prompt = self.task.get_generate_dataset_prompt(label)
 
             result = self.llm.label([prompt])
             if result.errors[0] is not None:
-                print(f"Error generating rows for label {label}: {result.errors[0]}")
+                self.console.print(
+                    f"Error generating rows for label {label}: {result.errors[0]}"
+                )
             else:
                 response = result.generations[0][0].text.strip()
 
                 response = io.StringIO(response)
                 label_df = pd.read_csv(response, sep=self.config.delimiter())
                 label_df[self.config.label_column()] = label
-                df = pd.concat([df, label_df], axis=0)
+                df = pd.concat([df, label_df], axis=0, ignore_index=True)
         return AutolabelDataset(df, self.config)
 
     def clear_cache(self, use_ttl: bool = True):

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -61,7 +61,7 @@ class LabelingAgent:
         self.db = StateManager() if self.create_task else None
         self.generation_cache = SQLAlchemyGenerationCache() if cache else None
         self.transform_cache = SQLAlchemyTransformCache() if cache else None
-        self.console = Console() if console_output else Console(quiet=True)
+        self.console = Console(quiet=not console_output)
 
         self.config = (
             config if isinstance(config, AutolabelConfig) else AutolabelConfig(config)

--- a/src/autolabel/utils.py
+++ b/src/autolabel/utils.py
@@ -240,10 +240,11 @@ def track_with_stats(
     )
     stats_progress = Progress(
         TextColumn("{task.fields[stats]}"),
+        console=console,
     )
 
     group = Group(progress, stats_progress)
-    live = Live(group)
+    live = Live(group, console=console)
 
     if total is None:
         total = len(sequence)


### PR DESCRIPTION
If the `run` method was stopped by kill signal while a progress bar was being displayed, the next time the `run` method would be run would result in the error `LiveError: Only one live display may be active at once`. This was fixed by setting self.console to Console(quiet=not console_output) instead of writing an if statement whenever printing output.

Additionally, when generating synthetic datasets, the index would repeat for every label (0, 1, 2, 0, 1, 2, ...) when we simply want the index to be a sequence from 0 to n-1. This was fixed by setting `ignore_index` to `True` when concatenating dataframes. A progress bar was also added for generating synthetic datasets.