### PR TITLE
Increase pool size and record prompts after labeling

### DIFF
--- a/src/autolabel/database/engine.py
+++ b/src/autolabel/database/engine.py
@@ -17,5 +17,5 @@ DB_PATH = ".autolabel.v15.db"
 def create_db_engine(db_path: Optional[str] = DB_PATH) -> Engine:
     global DB_ENGINE
     if DB_ENGINE is None:
-        DB_ENGINE = create_engine(f"sqlite:///{db_path}")
+        DB_ENGINE = create_engine(f"sqlite:///{db_path}", pool_size=0)
     return DB_ENGINE

--- a/src/autolabel/dataset/dataset.py
+++ b/src/autolabel/dataset/dataset.py
@@ -106,6 +106,9 @@ class AutolabelDataset:
         # Add the LLM errors to the dataframe
         self.df[self.generate_label_name("error")] = [x.error for x in llm_labels]
 
+        # Add the LLM prompts to the dataframe
+        self.df[self.generate_label_name("prompt")] = [x.prompt for x in llm_labels]
+
         # Add labeled success column to the dataframe
         self.df[self.generate_label_name("successfully_labeled")] = [
             x.successfully_labeled for x in llm_labels


### PR DESCRIPTION
- Remove limit from concurrent read requests to sqlite
- Record the prompt that was sent to the model for every labeling run