### PR TITLE
Bump black from 22.10.0 to 23.3.0 in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.3.0
     hooks:
     - id: black
       language_version: python3


### PR DESCRIPTION
Update black version in pre-commit hooks to ensure compatibility with PR merge workflows.