### PR TITLE
Chunking for confidence if context exceeds context length

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "tabulate >= 0.9.0",
     "typer[all] >= 0.9.0",
     "simple-term-menu >= 1.6.1",
-    "tiktoken >= 0.3.3"
+    "transformers >= 4.25.0",
 ]
 requires-python = ">=3.6"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
     "jsonschema >= 4.17.3",
     "tabulate >= 0.9.0",
     "typer[all] >= 0.9.0",
-    "simple-term-menu >= 1.6.1"
+    "simple-term-menu >= 1.6.1",
+    "tiktoken >= 0.3.3"
 ]
 requires-python = ">=3.6"
 

--- a/src/autolabel/confidence.py
+++ b/src/autolabel/confidence.py
@@ -7,8 +7,9 @@ import requests
 import scipy.stats as stats
 import os
 import logging
+import tiktoken
 
-from autolabel.schema import LLMAnnotation, ConfidenceCacheEntry
+from autolabel.schema import LLMAnnotation, ConfidenceCacheEntry, AggregationFunction
 from autolabel.models import BaseModel
 from autolabel.cache import BaseCache, SQLAlchemyConfidenceCache
 
@@ -21,20 +22,31 @@ from tenacity import (
 
 logger = logging.getLogger(__name__)
 
+MERGE_FUNCTION = {
+    AggregationFunction.MAX: np.max,
+    AggregationFunction.MEAN: np.mean,
+}
+
 
 class ConfidenceCalculator:
     TTL_MS = 60 * 60 * 24 * 365 * 3 * 1000  # 3 years
+    MAX_CONTEXT_LENGTH = 3400  # Update this once confidence API supports longer prompts
 
     def __init__(
         self,
         score_type: str = "logprob_average",
         llm: Optional[BaseModel] = None,
         cache: Optional[BaseCache] = None,
+        confidence_chunk_size=0,
+        confidence_merge_function=AggregationFunction.MAX,
     ) -> None:
         self.score_type = score_type
         self.llm = llm
         self.cache = cache
         self.tokens_to_ignore = {"<unk>", "", "\\n"}
+        self.encoding_tokenizer = tiktoken.encoding_for_model("gpt-3.5-turbo")
+        self.confidence_chunk_size = confidence_chunk_size
+        self.confidence_merge_function = MERGE_FUNCTION[confidence_merge_function]
         self.SUPPORTED_CALCULATORS = {
             "logprob_average": self.logprob_average,
             "p_true": self.p_true,
@@ -86,7 +98,7 @@ class ConfidenceCalculator:
         indices = []
         for ind, logprob in enumerate(logprobs):
             key = list(logprob.keys())[0]
-            if key == '"' or key == '",':
+            if '"' in key:
                 indices.append(ind)
         if len(indices) != 4 * len(keys):
             logger.error("Unable to find all keys in prompt")
@@ -124,7 +136,7 @@ class ConfidenceCalculator:
                 return -math.e ** token[token_str]
         return 0
 
-    def calculate(self, model_generation: LLMAnnotation, **kwargs) -> float:
+    def calculate_chunk(self, model_generation: LLMAnnotation, **kwargs) -> float:
         if self.score_type not in self.SUPPORTED_CALCULATORS:
             raise NotImplementedError()
 
@@ -181,6 +193,45 @@ class ConfidenceCalculator:
         model_generation.confidence_score = confidence
         return confidence
 
+    def calculate(self, model_generation: LLMAnnotation, **kwargs) -> float:
+        full_prompt = model_generation.prompt + model_generation.raw_response
+        if not self.confidence_chunk_size or len(full_prompt) < self.MAX_CONTEXT_LENGTH:
+            return self.calculate_chunk(model_generation, **kwargs)
+        else:
+            # Split the model_input into chunks of size self.confidence_chunk_size
+            chunks = [
+                full_prompt[i : i + self.confidence_chunk_size]
+                for i in range(0, len(full_prompt), self.confidence_chunk_size)
+            ]
+
+            # Compute confidence for each chunk
+            confidence = []
+            for chunk in chunks:
+                confidence.append(
+                    self.calculate_chunk(
+                        LLMAnnotation(
+                            prompt=chunk,
+                            raw_response=model_generation.raw_response,
+                            generation_info=model_generation.generation_info,
+                            label=model_generation.label,
+                            successfully_labeled=model_generation.successfully_labeled,
+                        ),
+                        **kwargs,
+                    )
+                )
+
+            # Merge the confidence scores
+            merged_confidence = None
+            if isinstance(confidence[0], dict):
+                merged_confidence = {}
+                for key in confidence[0].keys():
+                    merged_confidence[key] = self.confidence_merge_function(
+                        [conf[key] for conf in confidence]
+                    )
+            else:
+                merged_confidence = self.confidence_merge_function(confidence)
+            return merged_confidence
+
     @retry(
         reraise=True,
         stop=stop_after_attempt(5),
@@ -217,6 +268,32 @@ class ConfidenceCalculator:
                 f"Unable to compute confidence score: {e}",
             )
             return [{"": 0.5}]
+
+    # def compute_confidence(self, model_input, model_output) -> Union[dict, List[dict]]:
+    #     prompt = model_input + model_output
+    #     num_tokens = len(self.encoding_tokenizer.encode(prompt))
+    #     if not self.confidence_chunk_size or num_tokens < self.MAX_CONTEXT_LENGTH:
+    #         return self.compute_confidence_for_chunk(model_input, model_output)
+    #     else:
+    #         # Split the model_input into chunks of size self.MAX_CONTEXT_LENGTH
+    #         chunks = [
+    #             model_input[i : i + self.MAX_CONTEXT_LENGTH]
+    #             for i in range(0, len(model_input), self.MAX_CONTEXT_LENGTH)
+    #         ]
+
+    #         # Compute confidence for each chunk
+    #         confidence = []
+    #         for chunk in chunks:
+    #             confidence.append(
+    #                 self.compute_confidence_for_chunk(chunk, model_output)
+    #             )
+
+    #         # Merge the confidence scores
+    #         merged_confidence = None
+    #         if isinstance(confidence[0], dict):
+    #             merged_confidence = {}
+    #             for key in confidence[0].keys():
+    #                 merged_confidence[key] = np.mean([conf[key] for conf in confidence])
 
     @classmethod
     def compute_completion(cls, confidence: List[float], threshold: float) -> float:

--- a/src/autolabel/configs/config.py
+++ b/src/autolabel/configs/config.py
@@ -17,6 +17,7 @@ class AutolabelConfig(BaseConfig):
     EMBEDDING_CONFIG_KEY = "embedding"
     PROMPT_CONFIG_KEY = "prompt"
     DATASET_GENERATION_CONFIG_KEY = "dataset_generation"
+    CHUNKING_CONFIG_KEY = "chunking"
 
     # Dataset config keys (config["dataset"][<key>])
     LABEL_COLUMN_KEY = "label_column"
@@ -58,6 +59,10 @@ class AutolabelConfig(BaseConfig):
     DATASET_GENERATION_GUIDELINES_KEY = "guidelines"
     DATASET_GENERATION_NUM_ROWS_KEY = "num_rows"
 
+    # Chunking config keys (config["chunking"][<key>])
+    CONFIDENCE_CHUNK_SIZE_KEY = "confidence_chunk_size"
+    CONFIDENCE_MERGE_FUNCTION_KEY = "confidence_merge_function"
+
     def __init__(self, config: Union[str, Dict], validate: bool = True) -> None:
         super().__init__(config, validate=validate)
 
@@ -95,6 +100,11 @@ class AutolabelConfig(BaseConfig):
     def _dataset_generation_config(self) -> Dict:
         """Returns information about the prompt for synthetic dataset generation"""
         return self.config.get(self.DATASET_GENERATION_CONFIG_KEY, {})
+
+    @cached_property
+    def _chunking_config(self) -> Dict:
+        """Returns information about the chunking config"""
+        return self.config.get(self.CHUNKING_CONFIG_KEY, {})
 
     # project and task definition config
     def task_name(self) -> str:
@@ -243,3 +253,11 @@ class AutolabelConfig(BaseConfig):
         return self._dataset_generation_config.get(
             self.DATASET_GENERATION_NUM_ROWS_KEY, 1
         )
+
+    def confidence_chunk_size(self) -> int:
+        """Returns the chunk size for confidence chunking"""
+        return self._chunking_config.get(self.CONFIDENCE_CHUNK_SIZE_KEY, 0)
+
+    def confidence_merge_function(self) -> str:
+        """Returns the function to use when merging confidence scores"""
+        return self._chunking_config.get(self.CONFIDENCE_MERGE_FUNCTION_KEY, "max")

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -301,6 +301,7 @@ class LabelingAgent:
                                 key_to_chunk = None
                                 for key in chunk.keys():
                                     # TODO(rajas): Better way to find the key to chunk
+                                    # Potentially take this as an input from the user
                                     if (
                                         self.get_num_tokens(chunk[key])
                                         > num_tokens_per_chunk

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -107,7 +107,11 @@ class LabelingAgent:
         if self.config.task_type() == TaskType.ATTRIBUTE_EXTRACTION:
             score_type = "logprob_average_per_key"
         self.confidence = ConfidenceCalculator(
-            score_type=score_type, llm=self.llm, cache=self.confidence_cache
+            score_type=score_type,
+            llm=self.llm,
+            cache=self.confidence_cache,
+            confidence_chunk_size=self.config.confidence_chunk_size(),
+            confidence_merge_function=self.config.confidence_merge_function(),
         )
 
         self.example_selector = example_selector

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -304,7 +304,7 @@ class LabelingAgent:
                                     # Potentially take this as an input from the user
                                     if (
                                         self.get_num_tokens(chunk[key])
-                                        > num_tokens_per_chunk
+                                        > self.CONFIDENCE_MAX_CONTEXT_LENGTH
                                     ):
                                         key_to_chunk = key
                                         break

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -333,7 +333,6 @@ class LabelingAgent:
                                         new_chunk, examples
                                     )
                                     annotation_dict = annotation.dict()
-                                    print(self.get_num_tokens(new_prompt))
                                     annotation_dict["prompt"] = new_prompt
                                     confidence_scores.append(
                                         self.confidence.calculate(

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -298,19 +298,9 @@ class LabelingAgent:
                                     model_generation=annotation,
                                 )
                             else:
-                                empty_chunk = {k: "" for k in chunk.keys()}
-                                empty_prompt = self.task.construct_prompt(
-                                    empty_chunk, examples
-                                )
-                                num_tokens_empty_prompt = self.get_num_tokens(
-                                    empty_prompt
-                                )
-                                num_tokens_per_chunk = (
-                                    self.config.confidence_chunk_size()
-                                    - num_tokens_empty_prompt
-                                )
                                 key_to_chunk = None
                                 for key in chunk.keys():
+                                    # TODO(rajas): Better way to find the key to chunk
                                     if (
                                         self.get_num_tokens(chunk[key])
                                         > num_tokens_per_chunk
@@ -321,6 +311,19 @@ class LabelingAgent:
                                     raise ValueError(
                                         f"Unable to find a key in the chunk with a value that is longer than {num_tokens_per_chunk} tokens."
                                     )
+
+                                empty_chunk = chunk.copy()
+                                empty_chunk[key_to_chunk] = ""
+                                empty_prompt = self.task.construct_prompt(
+                                    empty_chunk, examples
+                                )
+                                num_tokens_empty_prompt = self.get_num_tokens(
+                                    empty_prompt
+                                )
+                                num_tokens_per_chunk = (
+                                    self.config.confidence_chunk_size()
+                                    - num_tokens_empty_prompt
+                                )
                                 confidence_chunks = self.chunk_string(
                                     chunk[key_to_chunk], num_tokens_per_chunk
                                 )

--- a/src/autolabel/schema.py
+++ b/src/autolabel/schema.py
@@ -270,3 +270,10 @@ class RefuelLLMResult(BaseModel):
 
     """Costs incurred during the labeling job"""
     costs: Optional[List[float]] = []
+
+
+class AggregationFunction(str, Enum):
+    """Enum of supported aggregation functions"""
+
+    MAX = "max"
+    MEAN = "mean"


### PR DESCRIPTION
In this PR, we will chunk confidence prompts in order to support getting confidence from a model having context length smaller than the context length supported by the generation model. We do this by chunking the document into smaller chunks and sending the prompt along with the smaller chunks of the document. we support multiple aggregation functions over the confidence chunks. 

For extraction, max makes more sense than mean which might make more sense for a classification task