### PR TITLE
Set explanation column default back to None

### DIFF
--- a/src/autolabel/configs/config.py
+++ b/src/autolabel/configs/config.py
@@ -135,7 +135,7 @@ class AutolabelConfig(BaseConfig):
 
     def explanation_column(self) -> str:
         """Returns the name of the column containing an explanation as to why the data is labeled a certain way"""
-        return self._dataset_config.get(self.EXPLANATION_COLUMN_KEY, "explanation")
+        return self._dataset_config.get(self.EXPLANATION_COLUMN_KEY, None)
 
     def image_column(self) -> str:
         """Returns the name of the column containing an image url for the given item"""


### PR DESCRIPTION
Set's explanation column's default value back to `None`. 