### PR TITLE
Adding support for trimming prompt based on max context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ huggingface = [
     "sentence_transformers"
 ]
 google = [
+    "tiktoken >= 0.3.3",
     "google-cloud-aiplatform>=1.25.0"
 ]
 cohere = [

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -269,10 +269,19 @@ class LabelingAgent:
             ):
                 selected_labels = self.label_selector.select_labels(chunk["example"])
                 final_prompt = self.task.construct_prompt(
-                    chunk, examples, selected_labels=selected_labels
+                    chunk,
+                    examples,
+                    selected_labels=selected_labels,
+                    max_input_tokens=self.llm.DEFAULT_CONTEXT_LENGTH,
+                    get_num_tokens=self.llm.get_num_tokens,
                 )
             else:
-                final_prompt = self.task.construct_prompt(chunk, examples)
+                final_prompt = self.task.construct_prompt(
+                    chunk,
+                    examples,
+                    max_input_tokens=self.llm.DEFAULT_CONTEXT_LENGTH,
+                    get_num_tokens=self.llm.get_num_tokens,
+                )
 
             response = self.llm.label([final_prompt])
             for i, generations, error, latency in zip(
@@ -488,10 +497,19 @@ class LabelingAgent:
             ):
                 selected_labels = self.label_selector.select_labels(input_i["example"])
                 final_prompt = self.task.construct_prompt(
-                    input_i, examples, selected_labels=selected_labels
+                    input_i,
+                    examples,
+                    selected_labels=selected_labels,
+                    max_input_tokens=self.llm.DEFAULT_CONTEXT_LENGTH,
+                    get_num_tokens=self.llm.get_num_tokens,
                 )
             else:
-                final_prompt = self.task.construct_prompt(input_i, examples)
+                final_prompt = self.task.construct_prompt(
+                    input_i,
+                    examples,
+                    max_input_tokens=self.llm.DEFAULT_CONTEXT_LENGTH,
+                    get_num_tokens=self.llm.get_num_tokens,
+                )
             prompt_list.append(final_prompt)
 
             # Calculate the number of tokens

--- a/src/autolabel/models/base.py
+++ b/src/autolabel/models/base.py
@@ -18,6 +18,7 @@ from langchain.schema import Generation
 
 class BaseModel(ABC):
     TTL_MS = 60 * 60 * 24 * 365 * 3 * 1000  # 3 years
+    DEFAULT_CONTEXT_LENGTH = None
 
     def __init__(self, config: AutolabelConfig, cache: BaseCache) -> None:
         self.config = config
@@ -165,4 +166,10 @@ class BaseModel(ABC):
         Returns:
             bool: whether the LLM returns supports returning logprobs of generated tokens
         """
+        pass
+
+    @abstractmethod
+    def get_num_tokens(self, prompt: str) -> int:
+        """
+        Get the number of tokens in the prompt"""
         pass

--- a/src/autolabel/models/palm.py
+++ b/src/autolabel/models/palm.py
@@ -49,6 +49,7 @@ class PaLMLLM(BaseModel):
         try:
             from langchain.chat_models import ChatVertexAI
             from langchain.llms import VertexAI
+            import tiktoken
         except ImportError:
             raise ImportError(
                 "palm is required to use the Palm LLM. Please install it with the following command: pip install 'refuel-autolabel[google]'"
@@ -67,6 +68,7 @@ class PaLMLLM(BaseModel):
             self.llm = ChatVertexAI(model_name=self.model_name, **self.model_params)
         else:
             self.llm = VertexAI(model_name=self.model_name, **self.model_params)
+        self.tiktoken = tiktoken
 
     @retry(
         reraise=True,
@@ -163,4 +165,6 @@ class PaLMLLM(BaseModel):
         return False
 
     def get_num_tokens(self, prompt: str) -> int:
-        return len(prompt)
+        # TODO(dhruva): Replace with actual tokenizer once that is available
+        encoding = self.tiktoken.encoding_for_model("gpt2")
+        return len(encoding.encode(prompt))

--- a/src/autolabel/models/refuel.py
+++ b/src/autolabel/models/refuel.py
@@ -28,7 +28,7 @@ class UnretryableError(Exception):
 
 
 class RefuelLLM(BaseModel):
-    DEFAULT_CONTEXT_LENGTH = 3500
+    DEFAULT_CONTEXT_LENGTH = 3250
     DEFAULT_PARAMS = {
         "max_new_tokens": 128,
     }

--- a/src/autolabel/tasks/attribute_extraction.py
+++ b/src/autolabel/tasks/attribute_extraction.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Union
+from typing import Callable, Dict, List, Optional, Union
 from collections import defaultdict
 import logging
 import json
@@ -95,6 +95,8 @@ class AttributeExtractionTask(BaseTask):
         prompt_template_override: PromptTemplate = None,
         refuel_prompt_override: bool = False,
         output_guidelines_override: str = None,
+        max_input_tokens: int = None,
+        get_num_tokens: Optional[Callable] = None,
         **kwargs,
     ) -> str:
         fmt_task_guidelines = self.task_guidelines
@@ -126,17 +128,23 @@ class AttributeExtractionTask(BaseTask):
             else prompt_template_override
         )
         if self._is_few_shot_mode():
-            curr_text_prompt = prompt_template.format(
+            curr_text_prompt = self.trim_prompt(
+                prompt_template,
                 task_guidelines=fmt_task_guidelines,
                 output_guidelines=fmt_output_guidelines,
                 seed_examples="\n\n".join(fmt_examples),
                 current_example=current_example,
+                max_input_tokens=max_input_tokens,
+                get_num_tokens=get_num_tokens,
             )
         else:
-            curr_text_prompt = prompt_template.format(
+            curr_text_prompt = self.trim_prompt(
+                prompt_template,
                 task_guidelines=fmt_task_guidelines,
                 output_guidelines=fmt_output_guidelines,
                 current_example=current_example,
+                max_input_tokens=max_input_tokens,
+                get_num_tokens=get_num_tokens,
             )
 
         if self.image_col is not None:

--- a/src/autolabel/tasks/classification.py
+++ b/src/autolabel/tasks/classification.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import List, Dict, Tuple
+from typing import List, Callable, Dict, Optional, Tuple
 import logging
 
 from langchain.prompts.prompt import PromptTemplate
@@ -65,6 +65,8 @@ class ClassificationTask(BaseTask):
         prompt_template_override: PromptTemplate = None,
         refuel_prompt_override: bool = False,
         output_guidelines_override: str = None,
+        max_input_tokens: int = None,
+        get_num_tokens: Optional[Callable] = None,
         **kwargs,
     ) -> str:
         # Copy over the input so that we can modify it
@@ -121,17 +123,23 @@ class ClassificationTask(BaseTask):
             else output_guidelines_override
         )
         if self._is_few_shot_mode():
-            curr_text_prompt = prompt_template.format(
+            curr_text_prompt = self.trim_prompt(
+                prompt_template,
                 task_guidelines=fmt_task_guidelines,
                 output_guidelines=output_guidelines,
-                seed_examples="\n".join(fmt_examples),
+                seed_examples="\n\n".join(fmt_examples),
                 current_example=current_example,
+                max_input_tokens=max_input_tokens,
+                get_num_tokens=get_num_tokens,
             )
         else:
-            curr_text_prompt = prompt_template.format(
+            curr_text_prompt = self.trim_prompt(
+                prompt_template,
                 task_guidelines=fmt_task_guidelines,
-                output_guidelines=self.output_guidelines,
+                output_guidelines=output_guidelines,
                 current_example=current_example,
+                max_input_tokens=max_input_tokens,
+                get_num_tokens=get_num_tokens,
             )
         if self.image_col is not None:
             return json.dumps(

--- a/src/autolabel/tasks/entity_matching.py
+++ b/src/autolabel/tasks/entity_matching.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import List, Dict, Tuple
+from typing import List, Callable, Dict, Optional, Tuple
 import json
 import logging
 
@@ -62,6 +62,8 @@ class EntityMatchingTask(BaseTask):
         prompt_template_override: PromptTemplate = None,
         refuel_prompt_override: bool = False,
         output_guidelines_override: str = None,
+        max_input_tokens: int = None,
+        get_num_tokens: Optional[Callable] = None,
         **kwargs,
     ) -> str:
         # Copy over the input so that we can modify it
@@ -107,17 +109,23 @@ class EntityMatchingTask(BaseTask):
             else output_guidelines_override
         )
         if self._is_few_shot_mode():
-            curr_text_prompt = prompt_template.format(
+            curr_text_prompt = self.trim_prompt(
+                prompt_template,
                 task_guidelines=fmt_task_guidelines,
                 output_guidelines=output_guidelines,
                 seed_examples="\n\n".join(fmt_examples),
                 current_example=current_example,
+                max_input_tokens=max_input_tokens,
+                get_num_tokens=get_num_tokens,
             )
         else:
-            curr_text_prompt = prompt_template.format(
+            curr_text_prompt = self.trim_prompt(
+                prompt_template,
                 task_guidelines=fmt_task_guidelines,
                 output_guidelines=output_guidelines,
                 current_example=current_example,
+                max_input_tokens=max_input_tokens,
+                get_num_tokens=get_num_tokens,
             )
 
         if self.image_col is not None:

--- a/src/autolabel/tasks/multilabel_classification.py
+++ b/src/autolabel/tasks/multilabel_classification.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import List, Dict, Tuple
+from typing import List, Callable, Dict, Optional, Tuple
 
 from langchain.prompts.prompt import PromptTemplate
 
@@ -50,6 +50,8 @@ class MultilabelClassificationTask(BaseTask):
         prompt_template_override: PromptTemplate = None,
         refuel_prompt_override: bool = False,
         output_guidelines_override: str = None,
+        max_input_tokens: int = None,
+        get_num_tokens: Optional[Callable] = None,
         **kwargs,
     ) -> str:
         # Copy over the input so that we can modify it
@@ -95,17 +97,23 @@ class MultilabelClassificationTask(BaseTask):
             else output_guidelines_override
         )
         if self._is_few_shot_mode():
-            curr_text_prompt = prompt_template.format(
+            curr_text_prompt = self.trim_prompt(
+                prompt_template,
                 task_guidelines=fmt_task_guidelines,
                 output_guidelines=output_guidelines,
                 seed_examples="\n\n".join(fmt_examples),
                 current_example=current_example,
+                max_input_tokens=max_input_tokens,
+                get_num_tokens=get_num_tokens,
             )
         else:
-            curr_text_prompt = prompt_template.format(
+            curr_text_prompt = self.trim_prompt(
+                prompt_template,
                 task_guidelines=fmt_task_guidelines,
                 output_guidelines=output_guidelines,
                 current_example=current_example,
+                max_input_tokens=max_input_tokens,
+                get_num_tokens=get_num_tokens,
             )
         if self.image_col is not None:
             return json.dumps(

--- a/src/autolabel/tasks/named_entity_recognition.py
+++ b/src/autolabel/tasks/named_entity_recognition.py
@@ -1,7 +1,7 @@
 import json
 import re
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 from copy import deepcopy
 from langchain.prompts.prompt import PromptTemplate
 
@@ -69,6 +69,8 @@ class NamedEntityRecognitionTask(BaseTask):
         prompt_template_override: PromptTemplate = None,
         refuel_prompt_override: bool = False,
         output_guidelines_override: str = None,
+        max_input_tokens: int = None,
+        get_num_tokens: Optional[Callable] = None,
         **kwargs,
     ) -> str:
         # prepare task guideline
@@ -110,17 +112,23 @@ class NamedEntityRecognitionTask(BaseTask):
             else output_guidelines_override
         )
         if self._is_few_shot_mode():
-            curr_text_prompt = prompt_template.format(
+            curr_text_prompt = self.trim_prompt(
+                prompt_template,
                 task_guidelines=fmt_task_guidelines,
                 output_guidelines=output_guidelines,
                 seed_examples="\n\n".join(fmt_examples),
                 current_example=current_example,
+                max_input_tokens=max_input_tokens,
+                get_num_tokens=get_num_tokens,
             )
         else:
-            curr_text_prompt = prompt_template.format(
+            curr_text_prompt = self.trim_prompt(
+                prompt_template,
                 task_guidelines=fmt_task_guidelines,
                 output_guidelines=output_guidelines,
                 current_example=current_example,
+                max_input_tokens=max_input_tokens,
+                get_num_tokens=get_num_tokens,
             )
 
         if self.image_col is not None:

--- a/src/autolabel/tasks/question_answering.py
+++ b/src/autolabel/tasks/question_answering.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import List, Dict, Tuple, Optional
+from typing import Callable, Dict, List, Tuple, Optional
 import json
 
 from langchain.prompts.prompt import PromptTemplate
@@ -62,6 +62,8 @@ class QuestionAnsweringTask(BaseTask):
         prompt_template_override: PromptTemplate = None,
         refuel_prompt_override: bool = False,
         output_guidelines_override: str = None,
+        max_input_tokens: int = None,
+        get_num_tokens: Optional[Callable] = None,
         **kwargs,
     ) -> str:
         # Copy over the input so that we can modify it


### PR DESCRIPTION
# Pull Review Summary

## Description

Adding default max tokens for all models. Ensures that prompts are always trimmed to fit in the input context of the provided model.

## Type of change

- Bug fix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- This change requires a documentation update

## Tests

Ran banking.ipynb locally with and without examples that exceeded 3250 tokens for the refuel llm model.
