### PR TITLE
Minor broken link fixes

### DIFF
--- a/docs/guide/overview/getting-started.md
+++ b/docs/guide/overview/getting-started.md
@@ -89,11 +89,11 @@ config = {
 }
 ```
 
-*To create a custom configuration, you can use the [CLI](https://docs.refuel.ai/autolabel/guide/resources/CLI/) or [write your own](https://docs.refuel.ai/autolabel/guide/resources/configs/).*
+*To create a custom configuration, you can use the [CLI](guide/resources/CLI/) or [write your own](/guide/resources/configs/).*
 
 ### Preview the labeling against your dataset
 
-First import `autolabel`, create a `LabelingAgent` object and then run the `plan` command against the dataset (available [here](https://github.com/refuel-ai/autolabel/blob/main/docs/assets/movie_reviews.csv)) and can be downloaded through the `autolabel.get_data` function):
+First import `autolabel`, create a `LabelingAgent` object and then run the `plan` command against the dataset (available [here](https://github.com/refuel-ai/autolabel/docs/assets/movie_reviews.csv)) and can be downloaded through the `autolabel.get_data` function):
 
 ```python
 from autolabel import LabelingAgent, AutolabelDataset, get_data

--- a/docs/guide/overview/getting-started.md
+++ b/docs/guide/overview/getting-started.md
@@ -89,7 +89,7 @@ config = {
 }
 ```
 
-*To create a custom configuration, you can use the [CLI](https://docs.refuel.ai/guide/resources/CLI) or [write your own](https://docs.refuel.ai/guide/resources/configs/).*
+*To create a custom configuration, you can use the [CLI](https://docs.refuel.ai/autolabel/guide/resources/CLI/) or [write your own](https://docs.refuel.ai/autolabel/guide/resources/configs/).*
 
 ### Preview the labeling against your dataset
 

--- a/docs/guide/overview/getting-started.md
+++ b/docs/guide/overview/getting-started.md
@@ -93,7 +93,7 @@ config = {
 
 ### Preview the labeling against your dataset
 
-First import `autolabel`, create a `LabelingAgent` object and then run the `plan` command against the dataset (available [here](https://github.com/refuel-ai/autolabel/docs/assets/movie_reviews.csv)) and can be downloaded through the `autolabel.get_data` function):
+First import `autolabel`, create a `LabelingAgent` object and then run the `plan` command against the dataset (available [here](https://github.com/refuel-ai/autolabel/blob/main/docs/assets/movie_reviews.csv)) and can be downloaded through the `autolabel.get_data` function):
 
 ```python
 from autolabel import LabelingAgent, AutolabelDataset, get_data

--- a/docs/guide/resources/refuel_datasets.md
+++ b/docs/guide/resources/refuel_datasets.md
@@ -5,6 +5,7 @@ Autolabel provides datasets out-of-the-box so you can easily get started with LL
 | banking        | Classification        |
 | civil_comments | Classification        |
 | ledgar         | Classification        |
+| movie_reviews  | Classification        |
 | walmart_amazon | Entity Matching       |
 | company        | Entity Matching       |
 | squad_v2       | Question Answering    |


### PR DESCRIPTION
# Pull Review Summary
Minor broken link fixes

## Description

Seems like the issues come because of a revamp of the representation of the docs which now requires all links to have a `autolabel/*` format. 

## Type of change

- Bug fix (change which fixes an issue)

Future fix - 

- Revamping all of such links. Typically it is better to have relative links like `guide/resources/CLI/` instead of `https://docs.refuel.ai/autolabel/guide/resources/CLI/` to ensure backward compatibility. 