### PR TITLE
Safe formatting for task guidelines when constructing prompts

### DIFF
--- a/src/autolabel/tasks/classification.py
+++ b/src/autolabel/tasks/classification.py
@@ -86,8 +86,8 @@ class ClassificationTask(BaseTask):
         else:
             labels = "\n".join(labels_list)
 
-        fmt_task_guidelines = self.task_guidelines.format(
-            num_labels=num_labels, labels=labels
+        fmt_task_guidelines = self.task_guidelines.format_map(
+            defaultdict(str, labels="\n".join(labels_list), num_labels=num_labels)
         )
 
         # prepare seed examples

--- a/src/autolabel/tasks/entity_matching.py
+++ b/src/autolabel/tasks/entity_matching.py
@@ -72,8 +72,8 @@ class EntityMatchingTask(BaseTask):
         # prepare task guideline
         labels_list = self.config.labels_list()
         num_labels = len(labels_list)
-        fmt_task_guidelines = self.task_guidelines.format(
-            num_labels=num_labels, labels="\n".join(labels_list)
+        fmt_task_guidelines = self.task_guidelines.format_map(
+            defaultdict(str, labels="\n".join(labels_list), num_labels=num_labels)
         )
 
         # prepare seed examples

--- a/src/autolabel/tasks/multilabel_classification.py
+++ b/src/autolabel/tasks/multilabel_classification.py
@@ -18,6 +18,9 @@ from autolabel.metrics import (
     F1Metric,
     BaseMetric,
 )
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class MultilabelClassificationTask(BaseTask):
@@ -60,8 +63,8 @@ class MultilabelClassificationTask(BaseTask):
         # prepare task guideline
         labels_list = self.config.labels_list()
         num_labels = len(labels_list)
-        fmt_task_guidelines = self.task_guidelines.format(
-            num_labels=num_labels, labels="\n".join(labels_list)
+        fmt_task_guidelines = self.task_guidelines.format_map(
+            defaultdict(str, labels="\n".join(labels_list), num_labels=num_labels)
         )
 
         # prepare seed examples

--- a/src/autolabel/tasks/multilabel_classification.py
+++ b/src/autolabel/tasks/multilabel_classification.py
@@ -18,9 +18,6 @@ from autolabel.metrics import (
     F1Metric,
     BaseMetric,
 )
-import logging
-
-logger = logging.getLogger(__name__)
 
 
 class MultilabelClassificationTask(BaseTask):

--- a/src/autolabel/tasks/named_entity_recognition.py
+++ b/src/autolabel/tasks/named_entity_recognition.py
@@ -76,8 +76,8 @@ class NamedEntityRecognitionTask(BaseTask):
         # prepare task guideline
         labels_list = self.config.labels_list()
         num_labels = len(labels_list)
-        fmt_task_guidelines = self.task_guidelines.format(
-            num_labels=num_labels, labels="\n".join(labels_list)
+        fmt_task_guidelines = self.task_guidelines.format_map(
+            defaultdict(str, labels="\n".join(labels_list), num_labels=num_labels)
         )
 
         # prepare seed examples


### PR DESCRIPTION
# Pull Review Summary

## Description

Safe string formatting of the task guidelines when keys are not present

## Type of change

- Bug fix (change which fixes an issue)

## Tests

Tested with 2 tasks where the task guidelines contains text in curly braces, but the keys are not present when formatting -> Previously this led to an issue, now we safely format the guidelines without these keys.