### PR TITLE
Avoid throwing error if web search query template column is not found

### DIFF
--- a/src/autolabel/transforms/serp_api.py
+++ b/src/autolabel/transforms/serp_api.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import json
 from autolabel.cache import BaseCache
 from autolabel.transforms import BaseTransform
@@ -104,7 +105,7 @@ class SerpApi(BaseTransform):
                     TransformErrorType.INVALID_INPUT,
                     f"Missing query column: {col} in row {row}",
                 )
-        query = self.query_template.format(**row)
+        query = self.query_template.format_map(defaultdict(str, row))
         search_result = self.NULL_TRANSFORM_TOKEN
         if pd.isna(query) or query == self.NULL_TRANSFORM_TOKEN:
             raise TransformError(

--- a/src/autolabel/transforms/serper_api.py
+++ b/src/autolabel/transforms/serper_api.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import json
 from autolabel.cache import BaseCache
 from autolabel.transforms import BaseTransform
@@ -101,7 +102,7 @@ class SerperApi(BaseTransform):
                     TransformErrorType.INVALID_INPUT,
                     f"Missing query column: {col} in row {row}",
                 )
-        query = self.query_template.format(**row)
+        query = self.query_template.format_map(defaultdict(str, row))
         search_result = self.NULL_TRANSFORM_TOKEN
         if pd.isna(query) or query == self.NULL_TRANSFORM_TOKEN:
             raise TransformError(


### PR DESCRIPTION
# Pull Review Summary

## Description

Avoid error when column in query template is not found.

## Type of change

- Bug fix (change which fixes an issue)

## Tests

Tested locally with transform with a query template with a non-existent column