### PR TITLE
Changing default output to produce only necessary attributes

### DIFF
--- a/src/autolabel/tasks/attribute_extraction.py
+++ b/src/autolabel/tasks/attribute_extraction.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class AttributeExtractionTask(BaseTask):
     NULL_LABEL = {}
     DEFAULT_TASK_GUIDELINES = "You are an expert at extracting attributes from text. Given a piece of text, extract the required attributes."
-    DEFAULT_OUTPUT_GUIDELINES = "You will return the extracted attributes as a json with the following keys:\n{attribute_json}"
+    DEFAULT_OUTPUT_GUIDELINES = "You will return the extracted attributes as a json with the following keys:\n{attribute_json}. Only output labels for the fields that exist in the provided prompt. Do not output anything for attributes that are irrelevant to the given input."
     LABEL_FORMAT_IN_EXPLANATION = (
         " The explanation should end with - 'so, the answer is <label>.'"
     )

--- a/src/autolabel/tasks/attribute_extraction.py
+++ b/src/autolabel/tasks/attribute_extraction.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class AttributeExtractionTask(BaseTask):
     NULL_LABEL = {}
     DEFAULT_TASK_GUIDELINES = "You are an expert at extracting attributes from text. Given a piece of text, extract the required attributes."
-    DEFAULT_OUTPUT_GUIDELINES = "You will return the extracted attributes as a json with the following keys:\n{attribute_json}. Only output labels for the fields that exist in the provided prompt. Do not output anything for attributes that are irrelevant to the given input."
+    DEFAULT_OUTPUT_GUIDELINES = "You will return the extracted attributes as a json with the following keys:\n{attribute_json}. Only output labels for the attributes in the json that have a valid extracted value. Do not output anything for attributes that are irrelevant to the given input."
     LABEL_FORMAT_IN_EXPLANATION = (
         " The explanation should end with - 'so, the answer is <label>.'"
     )


### PR DESCRIPTION
# Pull Review Summary

## Description

Changing attribute extraction prompt to only produce the necessary keys. Enforcing that certain attributes always exist can be enforced by the user by specifying in task level prompt.

## Type of change

- Bug fix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- This change requires a documentation update

## Tests

Locally
