### PR TITLE
Continue web scrape if query column is missing from row

### DIFF
--- a/src/autolabel/transforms/serp_api.py
+++ b/src/autolabel/transforms/serp_api.py
@@ -99,12 +99,6 @@ class SerpApi(BaseTransform):
         return search_result
 
     async def _apply(self, row: Dict[str, Any]) -> Dict[str, Any]:
-        for col in self.query_columns:
-            if col not in row:
-                raise TransformError(
-                    TransformErrorType.INVALID_INPUT,
-                    f"Missing query column: {col} in row {row}",
-                )
         query = self.query_template.format_map(defaultdict(str, row))
         search_result = self.NULL_TRANSFORM_TOKEN
         if pd.isna(query) or query == self.NULL_TRANSFORM_TOKEN:

--- a/src/autolabel/transforms/serp_api.py
+++ b/src/autolabel/transforms/serp_api.py
@@ -99,6 +99,11 @@ class SerpApi(BaseTransform):
         return search_result
 
     async def _apply(self, row: Dict[str, Any]) -> Dict[str, Any]:
+        for col in self.query_columns:
+            if col not in row:
+                logger.error(
+                    f"Missing query column: {col} in row {row}",
+                )
         query = self.query_template.format_map(defaultdict(str, row))
         search_result = self.NULL_TRANSFORM_TOKEN
         if pd.isna(query) or query == self.NULL_TRANSFORM_TOKEN:

--- a/src/autolabel/transforms/serper_api.py
+++ b/src/autolabel/transforms/serper_api.py
@@ -96,13 +96,8 @@ class SerperApi(BaseTransform):
         return search_result
 
     async def _apply(self, row: Dict[str, Any]) -> Dict[str, Any]:
-        for col in self.query_columns:
-            if col not in row:
-                raise TransformError(
-                    TransformErrorType.INVALID_INPUT,
-                    f"Missing query column: {col} in row {row}",
-                )
         query = self.query_template.format_map(defaultdict(str, row))
+        query = ""
         search_result = self.NULL_TRANSFORM_TOKEN
         if pd.isna(query) or query == self.NULL_TRANSFORM_TOKEN:
             raise TransformError(

--- a/src/autolabel/transforms/serper_api.py
+++ b/src/autolabel/transforms/serper_api.py
@@ -96,6 +96,11 @@ class SerperApi(BaseTransform):
         return search_result
 
     async def _apply(self, row: Dict[str, Any]) -> Dict[str, Any]:
+        for col in self.query_columns:
+            if col not in row:
+                logger.error(
+                    f"Missing query column: {col} in row {row}",
+                )
         query = self.query_template.format_map(defaultdict(str, row))
         search_result = self.NULL_TRANSFORM_TOKEN
         if pd.isna(query) or query == self.NULL_TRANSFORM_TOKEN:

--- a/src/autolabel/transforms/serper_api.py
+++ b/src/autolabel/transforms/serper_api.py
@@ -97,7 +97,6 @@ class SerperApi(BaseTransform):
 
     async def _apply(self, row: Dict[str, Any]) -> Dict[str, Any]:
         query = self.query_template.format_map(defaultdict(str, row))
-        query = ""
         search_result = self.NULL_TRANSFORM_TOKEN
         if pd.isna(query) or query == self.NULL_TRANSFORM_TOKEN:
             raise TransformError(


### PR DESCRIPTION
# Pull Review Summary

## Description

Avoid blocking web scrape if a query column doesn't exist in a row. The query template will just not format that query column.

## Type of change

- Improvement

## Tests

Tested locally without query column in row