### PR TITLE
Add shorter connection timeout for webpage transform

### DIFF
--- a/src/autolabel/transforms/webpage_transform.py
+++ b/src/autolabel/transforms/webpage_transform.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 MAX_RETRIES = 5
 MAX_KEEPALIVE_CONNECTIONS = 20
+CONNECTION_TIMEOUT = 5
 MAX_CONNECTIONS = 100
 BACKOFF = 2
 HEADERS = {}
@@ -53,7 +54,7 @@ class WebpageTransform(BaseTransform):
 
             self.httpx = httpx
             self.timeout_time = timeout
-            self.timeout = httpx.Timeout(timeout)
+            self.timeout = httpx.Timeout(connect=CONNECTION_TIMEOUT, timeout=timeout)
             limits = httpx.Limits(
                 max_keepalive_connections=MAX_KEEPALIVE_CONNECTIONS,
                 max_connections=MAX_CONNECTIONS,

--- a/tests/unit/transforms/test_webpage_transform.py
+++ b/tests/unit/transforms/test_webpage_transform.py
@@ -77,3 +77,29 @@ async def test_empty_url():
         transformed_row["webpage_scrape_error"]
         == "INVALID_INPUT: Empty url in row {'url': 'NO_TRANSFORM'}"
     )
+
+
+@pytest.mark.asyncio
+async def test_unreachable_url():
+    # Initialize the transform class
+    transform = WebpageTransform(
+        output_columns={
+            "content_column": "webpage_content",
+        },
+        url_column="url",
+        cache=None,
+    )
+
+    # Create a mock row
+    row = {"url": "http://portal.net.kp/"}
+    # Transform the row
+    transformed_row = await transform.apply(row)
+    # Check the output
+    assert set(transformed_row.keys()) == set(
+        ["webpage_content", "webpage_scrape_error"]
+    )
+    assert transformed_row["webpage_content"] == "NO_TRANSFORM"
+    assert (
+        transformed_row["webpage_scrape_error"]
+        == "TRANSFORM_TIMEOUT: Timeout when fetching content from URL"
+    )


### PR DESCRIPTION
# Pull Review Summary
## Description
We want to keep the connection timeout to a shorter value so in case a url is unreachable, we are able to return quickly instead of waiting for entire 1 min which is the default read/write timeout.

## Type of change

- Bug fix (change which fixes an issue)