### PR TITLE
Fix exception logging when confidence score is not computed

### DIFF
--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -322,7 +322,7 @@ class LabelingAgent:
                                     f"Error calculating confidence score: {e}"
                                 )
                                 logger.error(
-                                    f"Could not calculate confidence score for annotation: {annotation.json()}"
+                                    f"Could not calculate confidence score for annotation: {annotation}"
                                 )
                                 if (
                                     self.config.task_type()


### PR DESCRIPTION
# Pull Review Summary

## Description

Annotation is not serializable. Fixing the logging the same.
## Type of change

- Bug fix (change which fixes an issue)

