### PR TITLE
Change log type to warning for confidence errors

### DIFF
--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -321,7 +321,7 @@ class LabelingAgent:
                                 logger.exception(
                                     f"Error calculating confidence score: {e}"
                                 )
-                                logger.error(
+                                logger.warning(
                                     f"Could not calculate confidence score for annotation: {annotation}"
                                 )
                                 if (


### PR DESCRIPTION
# Pull Review Summary

## Description

We already log the exception, so changing the log type to warning instead for the annotation.
