### PR TITLE
Use cache to speed up building dependencies for tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,4 +32,3 @@ jobs:
           OPENAI_API_KEY: "test_key"
           ANTHROPIC_API_KEY: "test_key"
           REFUEL_API_KEY: "test_key"
-          TEST_ENV: "True"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
+          cache: "pip"
       - name: Install autolabel
         run: |
           pip install '.[all]'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,3 +32,4 @@ jobs:
           OPENAI_API_KEY: "test_key"
           ANTHROPIC_API_KEY: "test_key"
           REFUEL_API_KEY: "test_key"
+          TEST_ENV: "True"


### PR DESCRIPTION
# Pull Review Summary

## Description

Using pip cache for caching autolabel dependencies to speed up tests.

## Type of change

- New feature (change which adds functionality)
