### PR TITLE
Change severity level to warning

### DIFF
--- a/src/autolabel/transforms/serp_api.py
+++ b/src/autolabel/transforms/serp_api.py
@@ -101,7 +101,7 @@ class SerpApi(BaseTransform):
     async def _apply(self, row: Dict[str, Any]) -> Dict[str, Any]:
         for col in self.query_columns:
             if col not in row:
-                logger.error(
+                logger.warning(
                     f"Missing query column: {col} in row {row}",
                 )
         query = self.query_template.format_map(defaultdict(str, row))

--- a/src/autolabel/transforms/serper_api.py
+++ b/src/autolabel/transforms/serper_api.py
@@ -98,7 +98,7 @@ class SerperApi(BaseTransform):
     async def _apply(self, row: Dict[str, Any]) -> Dict[str, Any]:
         for col in self.query_columns:
             if col not in row:
-                logger.error(
+                logger.warning(
                     f"Missing query column: {col} in row {row}",
                 )
         query = self.query_template.format_map(defaultdict(str, row))


### PR DESCRIPTION
# Pull Review Summary

## Description

We allow web search transforms to go through even if an expected query column is missing (it just doesn't get formatted in the template). So, this should be warning level.

## Type of change

- Nit