### PR TITLE
Add premium proxy on webpage transform retries

### DIFF
--- a/src/autolabel/transforms/webpage_scrape.py
+++ b/src/autolabel/transforms/webpage_scrape.py
@@ -101,7 +101,7 @@ class WebpageScrape(BaseTransform):
             if not verify:
                 client = self.client_with_no_verify
             response = await client.get(url, headers=headers)
-
+            response.raise_for_status()
             # TODO: Add support for other parsers
             content_bytes = response.content
             soup = self.beautiful_soup(content_bytes, HTML_PARSER)

--- a/src/autolabel/transforms/webpage_transform.py
+++ b/src/autolabel/transforms/webpage_transform.py
@@ -57,6 +57,7 @@ class WebpageTransform(BaseTransform):
         self.scrapingbee_params = {
             "timeout": self.timeout,
             "transparent_status_code": "True",
+            "js_scenario": JS_SCENARIO,
         }
 
     def name(self) -> str:
@@ -75,7 +76,6 @@ class WebpageTransform(BaseTransform):
         if retry_count > 0:
             logger.warning(f"Retrying scraping URL: {url} with premium proxy")
             self.scrapingbee_params[PREMIUM_PROXY_PARAM] = "True"
-            self.scrapingbee_params["js_scenario"] = JS_SCENARIO
 
         try:
             response = self.client.get(url, params=self.scrapingbee_params)


### PR DESCRIPTION
# Pull Review Summary

## Description

We currently run into errors when scraping certain domains. When we get an error on such requests, we will retry with a proxy to reduce the chance of error.

## Type of change

- New feature (change which adds functionality)

## Tests

Tested retry logic with proxy