### PR TITLE
Set transform cache when using task chaining

### DIFF
--- a/src/autolabel/task_chain/task_chain.py
+++ b/src/autolabel/task_chain/task_chain.py
@@ -156,7 +156,7 @@ class TaskChainOrchestrator:
                 for transform_dict in autolabel_config.transforms():
                     transform = TransformFactory.from_dict(
                         transform_dict,
-                        cache=None,
+                        cache=self.transform_cache,
                     )
                     dataset = await agent.async_run_transform(transform, dataset)
             else:


### PR DESCRIPTION
# Pull Review Summary

## Description

We should be using the transform cache if provided for task chaining.

## Type of change

- Bug fix (change which fixes an issue)

