### PR TITLE
Don't modify default query params directly

### DIFF
--- a/src/autolabel/models/openai.py
+++ b/src/autolabel/models/openai.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import os
 from functools import cached_property
@@ -139,7 +140,7 @@ class OpenAILLM(BaseModel):
 
         if self._engine == "chat":
             self.model_params = {**self.DEFAULT_PARAMS_CHAT_ENGINE, **model_params}
-            self.query_params = self.DEFAULT_QUERY_PARAMS_CHAT_ENGINE
+            self.query_params = copy.deepcopy(self.DEFAULT_QUERY_PARAMS_CHAT_ENGINE)
             self.llm = ChatOpenAI(
                 model_name=self.model_name, verbose=False, **self.model_params
             )


### PR DESCRIPTION
# Pull Review Summary

## Description

Currently, the default query params gets modified in a single instantiation of a LabelingAgent. This leads to issues when using the same LabelingAgent for multiple different LLM calls (for instance, when labeling and then generating an explanation, where we want to have different LLM config for both). This was leading to using an incorrect LLM config for the explanation generation LLM call.

## Type of change

- Bug fix (change which fixes an issue)

## Tests

Tested locally