### PR TITLE
Use replace for string formatting in task guidelines

### DIFF
--- a/src/autolabel/tasks/classification.py
+++ b/src/autolabel/tasks/classification.py
@@ -95,8 +95,8 @@ class ClassificationTask(BaseTask):
             else:
                 labels = "\n".join(labels_list)
 
-        fmt_task_guidelines = self.task_guidelines.format(
-            num_labels=num_labels, labels=labels
+        fmt_task_guidelines = self.task_guidelines.replace("{labels}", labels).replace(
+            "{num_labels}", str(num_labels)
         )
 
         # prepare seed examples
@@ -180,9 +180,9 @@ class ClassificationTask(BaseTask):
         # prepare task guideline
         labels_list = self.config.labels_list()
         num_labels = len(labels_list)
-        fmt_task_guidelines = self.task_guidelines.format(
-            num_labels=num_labels, labels="\n".join(labels_list)
-        )
+        fmt_task_guidelines = self.task_guidelines.replace(
+            "{labels}", "\n".join(labels_list)
+        ).replace("{num_labels}", str(num_labels))
 
         # prepare labeled example
         example_template = self.config.example_template()
@@ -207,9 +207,9 @@ class ClassificationTask(BaseTask):
         # prepare task guideline
         labels_list = self.config.labels_list()
         num_labels = len(labels_list)
-        fmt_task_guidelines = self.task_guidelines.format(
-            num_labels=num_labels, labels="\n".join(labels_list)
-        )
+        fmt_task_guidelines = self.task_guidelines.replace(
+            "{labels}", "\n".join(labels_list)
+        ).replace("{num_labels}", str(num_labels))
         fmt_guidelines = self.dataset_generation_guidelines.format(
             task_guidelines=fmt_task_guidelines
         )

--- a/src/autolabel/tasks/entity_matching.py
+++ b/src/autolabel/tasks/entity_matching.py
@@ -75,9 +75,9 @@ class EntityMatchingTask(BaseTask):
         # prepare task guideline
         labels_list = self.config.labels_list()
         num_labels = len(labels_list)
-        fmt_task_guidelines = self.task_guidelines.format_map(
-            defaultdict(str, labels="\n".join(labels_list), num_labels=num_labels)
-        )
+        fmt_task_guidelines = self.task_guidelines.replace(
+            "{labels}", "\n".join(labels_list)
+        ).replace("{num_labels}", str(num_labels))
 
         # prepare seed examples
         example_template = self.config.example_template()
@@ -160,9 +160,9 @@ class EntityMatchingTask(BaseTask):
         # prepare task guideline
         labels_list = self.config.labels_list()
         num_labels = len(labels_list)
-        fmt_task_guidelines = self.task_guidelines.format(
-            num_labels=num_labels, labels="\n".join(labels_list)
-        )
+        fmt_task_guidelines = self.task_guidelines.replace(
+            "{labels}", "\n".join(labels_list)
+        ).replace("{num_labels}", str(num_labels))
 
         # prepare labeled example
         example_template = self.config.example_template()
@@ -187,9 +187,9 @@ class EntityMatchingTask(BaseTask):
         # prepare task guideline
         labels_list = self.config.labels_list()
         num_labels = len(labels_list)
-        fmt_task_guidelines = self.task_guidelines.format(
-            num_labels=num_labels, labels="\n".join(labels_list)
-        )
+        fmt_task_guidelines = self.task_guidelines.replace(
+            "{labels}", "\n".join(labels_list)
+        ).replace("{num_labels}", str(num_labels))
         fmt_guidelines = self.dataset_generation_guidelines.format(
             task_guidelines=fmt_task_guidelines
         )

--- a/src/autolabel/tasks/multilabel_classification.py
+++ b/src/autolabel/tasks/multilabel_classification.py
@@ -152,9 +152,9 @@ class MultilabelClassificationTask(BaseTask):
         # prepare task guideline
         labels_list = self.config.labels_list()
         num_labels = len(labels_list)
-        fmt_task_guidelines = self.task_guidelines.format(
-            num_labels=num_labels, labels="\n".join(labels_list)
-        )
+        fmt_task_guidelines = self.task_guidelines.replace(
+            "{labels}", "\n".join(labels_list)
+        ).replace("{num_labels}", str(num_labels))
 
         # prepare labeled example
         example_template = self.config.example_template()

--- a/src/autolabel/tasks/named_entity_recognition.py
+++ b/src/autolabel/tasks/named_entity_recognition.py
@@ -78,9 +78,9 @@ class NamedEntityRecognitionTask(BaseTask):
         # prepare task guideline
         labels_list = self.config.labels_list()
         num_labels = len(labels_list)
-        fmt_task_guidelines = self.task_guidelines.format_map(
-            defaultdict(str, labels="\n".join(labels_list), num_labels=num_labels)
-        )
+        fmt_task_guidelines = self.task_guidelines.replace(
+            "{num_labels}", str(num_labels)
+        ).replace("{labels}", "\n".join(labels_list))
 
         # prepare seed examples
         label_column = self.config.label_column()


### PR DESCRIPTION
# Pull Review Summary

## Description

Use replace for string formatting in task guidelines for cases of unmatched braces

## Type of change

- Bug fix (change which fixes an issue)

## Tests

Tested locally