### PR TITLE
Return better error messages and types for labeling errors

### DIFF
--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -288,9 +288,7 @@ class LabelingAgent:
                 max_input_tokens=self.llm.DEFAULT_CONTEXT_LENGTH,
                 get_num_tokens=self.llm.get_num_tokens,
             )
-            logger.info(f"Prompt: {final_prompt}")
             response = await self.llm.label([final_prompt])
-            logger.info(f"Response: {response}")
             for i, generations, error, latency in zip(
                 range(len(response.generations)),
                 response.generations,

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -288,7 +288,9 @@ class LabelingAgent:
                 max_input_tokens=self.llm.DEFAULT_CONTEXT_LENGTH,
                 get_num_tokens=self.llm.get_num_tokens,
             )
+            logger.info(f"Prompt: {final_prompt}")
             response = await self.llm.label([final_prompt])
+            logger.info(f"Response: {response}")
             for i, generations, error, latency in zip(
                 range(len(response.generations)),
                 response.generations,

--- a/src/autolabel/schema.py
+++ b/src/autolabel/schema.py
@@ -94,10 +94,14 @@ class MetricResult(BaseModel):
 class ErrorType(str, Enum):
     """Enum of supported error types"""
 
+    CONTEXT_LENGTH_ERROR = "context_length_exceeded_error"
+    RATE_LIMIT_ERROR = "rate_limit_exceeded_error"
     LLM_PROVIDER_ERROR = "llm_provider_error"
     PARSING_ERROR = "parsing_error"
     OUTPUT_GUIDELINES_NOT_FOLLOWED_ERROR = "output_guidelines_not_followed_error"
     EMPTY_RESPONSE_ERROR = "empty_response_error"
+    INVALID_LLM_RESPONSE_ERROR = "invalid_llm_response_error"
+    NO_EXTRACTION_ERROR = "no_extraction_error"
 
 
 class LabelingError(BaseModel):

--- a/src/autolabel/tasks/attribute_extraction.py
+++ b/src/autolabel/tasks/attribute_extraction.py
@@ -227,11 +227,21 @@ class AttributeExtractionTask(BaseTask):
                     ).items()
                 }
                 successfully_labeled = True
+            except json.JSONDecodeError as e:
+                logger.error(
+                    f"Invalid JSON in LLM response: {response.text}, Error: {e}"
+                )
+                llm_label = self.NULL_LABEL
+                error = LabelingError(
+                    error_type=ErrorType.PARSING_ERROR,
+                    error_message=f"Unable to parse invalid JSON in LLM response.",
+                )
             except Exception as e:
                 logger.error(f"Error parsing LLM response: {response.text}, Error: {e}")
                 llm_label = self.NULL_LABEL
                 error = LabelingError(
-                    error_type=ErrorType.PARSING_ERROR, error_message=str(e)
+                    error_type=ErrorType.INVALID_LLM_RESPONSE_ERROR,
+                    error_message=str(e),
                 )
 
         # TODO(rajas): Handle output guidelines not followed error (for options case)

--- a/src/autolabel/tasks/attribute_extraction.py
+++ b/src/autolabel/tasks/attribute_extraction.py
@@ -227,15 +227,6 @@ class AttributeExtractionTask(BaseTask):
                     ).items()
                 }
                 successfully_labeled = True
-            except json.JSONDecodeError as e:
-                logger.error(
-                    f"Invalid JSON in LLM response: {response.text}, Error: {e}"
-                )
-                llm_label = self.NULL_LABEL
-                error = LabelingError(
-                    error_type=ErrorType.PARSING_ERROR,
-                    error_message=f"Unable to parse invalid JSON in LLM response.",
-                )
             except Exception as e:
                 logger.error(f"Error parsing LLM response: {response.text}, Error: {e}")
                 llm_label = self.NULL_LABEL

--- a/src/autolabel/tasks/base.py
+++ b/src/autolabel/tasks/base.py
@@ -245,7 +245,7 @@ class BaseTask(ABC):
             logger.warning("LLM response is empty")
             error = LabelingError(
                 error_type=ErrorType.EMPTY_RESPONSE_ERROR,
-                error_message="Empty response from LLM",
+                error_message="LLM response was empty.",
             )
         elif not completion_text:
             successfully_labeled = False
@@ -253,7 +253,7 @@ class BaseTask(ABC):
             logger.warning(f"Error parsing LLM response: {response.text}")
             error = LabelingError(
                 error_type=ErrorType.PARSING_ERROR,
-                error_message=f"Error parsing LLM response: {response.text}",
+                error_message=f"Error parsing LLM response.",
             )
         else:
             llm_label = completion_text.strip()
@@ -276,7 +276,7 @@ class BaseTask(ABC):
                     successfully_labeled = False
                     error = LabelingError(
                         error_type=ErrorType.OUTPUT_GUIDELINES_NOT_FOLLOWED_ERROR,
-                        error_message=f"LLM response: {llm_label} is not in the labels list",
+                        error_message=f"LLM response is not in the labels list.",
                     )
                     llm_label = self.NULL_LABEL_TOKEN
             elif self.config.task_type() == TaskType.MULTILABEL_CLASSIFICATION:
@@ -292,7 +292,7 @@ class BaseTask(ABC):
                     successfully_labeled = False
                     error = LabelingError(
                         error_type=ErrorType.OUTPUT_GUIDELINES_NOT_FOLLOWED_ERROR,
-                        error_message=f"LLM response: {llm_label} does not contain any valid labels in the labels list",
+                        error_message=f"LLM response does not contain any valid labels in the labels list.",
                     )
                     llm_label = self.NULL_LABEL_TOKEN
                 else:


### PR DESCRIPTION
# Pull Review Summary

## Description

Return better error messages and types for labeling errors by parsing LLM provider errors for appropriate error types when available. Still use default error types as fallback.

## Type of change

- New feature (change which adds functionality)

## Tests

Tested locally