### PR TITLE
Serp api query if input columns are empty

### DIFF
--- a/src/autolabel/transforms/serp_api.py
+++ b/src/autolabel/transforms/serp_api.py
@@ -105,7 +105,9 @@ class SerpApi(BaseTransform):
                 logger.error(
                     f"Missing query column: {col} in row {row}",
                 )
-        query = self.query_template.format_map(defaultdict(str, row))
+        query = self.query_template.format_map(
+            defaultdict(str, {key: val for key, val in row.items() if val is not None})
+        )
         search_result = self.NULL_TRANSFORM_TOKEN
         if pd.isna(query) or query == self.NULL_TRANSFORM_TOKEN:
             raise TransformError(

--- a/src/autolabel/transforms/serper_api.py
+++ b/src/autolabel/transforms/serper_api.py
@@ -102,7 +102,9 @@ class SerperApi(BaseTransform):
                 logger.error(
                     f"Missing query column: {col} in row {row}",
                 )
-        query = self.query_template.format_map(defaultdict(str, row))
+        query = self.query_template.format_map(
+            defaultdict(str, {key: val for key, val in row.items() if val is not None})
+        )
         search_result = self.NULL_TRANSFORM_TOKEN
         if pd.isna(query) or query == self.NULL_TRANSFORM_TOKEN:
             raise TransformError(


### PR DESCRIPTION
# Pull Review Summary

## Description

Serp api query if input columns are empty. Currently, if the inputs are empty i.e None, we send the string None to google. We should probably change that to an empty string by explicitly filtering this dictionary

## Type of change

- Bug fix (change which fixes an issue)

## Tests

