### PR TITLE
Max tokens for openai vision from config

### DIFF
--- a/src/autolabel/models/openai_vision.py
+++ b/src/autolabel/models/openai_vision.py
@@ -54,7 +54,8 @@ class OpenAIVisionLLM(BaseModel):
 
         # populate model name
         self.model_name = config.model_name() or self.DEFAULT_MODEL
-        self.model_params = self.DEFAULT_PARAMS_CHAT_ENGINE
+        model_params = config.model_params()
+        self.model_params = {**self.DEFAULT_PARAMS_CHAT_ENGINE, **model_params}
 
         if os.getenv("OPENAI_API_KEY") is None:
             raise ValueError("OPENAI_API_KEY environment variable not set")
@@ -63,7 +64,7 @@ class OpenAIVisionLLM(BaseModel):
         self.llm = partial(
             self.client.chat.completions.create,
             model=self.model_name,
-            max_tokens=self.DEFAULT_PARAMS_CHAT_ENGINE["max_tokens"],
+            max_tokens=self.model_params["max_tokens"],
         )
         self.tiktoken = tiktoken
         self.image_cols = config.image_columns()


### PR DESCRIPTION
# Pull Review Summary

## Description

OpenAI Vision requests are currently hardcoded to have max tokens of 300. Changing this to correctly read from model config

## Type of change

- [X] Bug fix (change which fixes an issue)
- New feature (change which adds functionality)
- This change requires a documentation update

## Tests
