### PR TITLE
Fixes multilabel confidence when there is a new line from the LLM

### DIFF
--- a/src/autolabel/confidence.py
+++ b/src/autolabel/confidence.py
@@ -102,11 +102,10 @@ class ConfidenceCalculator:
                 new_key = cur_key.split("\n")[-1].strip()
                 if not new_key:
                     logprobs = logprobs[i + 1 :]
-                    break
                 else:
                     logprobs[i] = {new_key: logprobs[i][cur_key]}
                     logprobs = logprobs[i:]
-                    break
+                break
 
         # Suppose the output for which we compute confidence is "Abc;Bcd;C"
         # In this case the logprobs can be a list of dictionaries like


### PR DESCRIPTION
# Pull Review Summary

## Description

Fixes multilabel confidence when there is a new line from the LLM. We ignore all the logprobs before the last \n from the LLM.

## Type of change

- Bug fix (change which fixes an issue)

## Tests

locally