### PR TITLE
Fallback logic in example template construction for format/format map errors

### DIFF
--- a/src/autolabel/tasks/attribute_extraction.py
+++ b/src/autolabel/tasks/attribute_extraction.py
@@ -127,13 +127,21 @@ class AttributeExtractionTask(BaseTask):
         try:
             current_example = example_template.format(**input)
         except KeyError as e:
-            current_example = example_template.format_map(defaultdict(str, input))
-            logger.warn(
-                f'\n\nKey {e} in the "example_template" in the given config'
-                f"\n\n{example_template}\n\nis not present in the datsaset columns - {input.keys()}.\n\n"
-                f"Input - {input}\n\n"
-                "Continuing with the prompt as {current_example}"
-            )
+            try:
+                current_example = example_template.format_map(defaultdict(str, input))
+                logger.warn(
+                    f'\n\nKey {e} in the "example_template" in the given config'
+                    f"\n\n{example_template}\n\nis not present in the datsaset columns - {input.keys()}.\n\n"
+                    f"Input - {input}\n\n"
+                    "Continuing with the prompt as {current_example}"
+                )
+            except AttributeError as e:
+                for key in input.keys():
+                    if input[key] is not None:
+                        example_template = example_template.replace(
+                            f"{{{key}}}", input[key]
+                        )
+                current_example = example_template
 
         # populate the current example in the prompt
         prompt_template = (

--- a/src/autolabel/tasks/classification.py
+++ b/src/autolabel/tasks/classification.py
@@ -115,13 +115,21 @@ class ClassificationTask(BaseTask):
         try:
             current_example = example_template.format(**input)
         except KeyError as e:
-            current_example = example_template.format_map(defaultdict(str, input))
-            logger.warn(
-                f'\n\nKey {e} in the "example_template" in the given config'
-                f"\n\n{example_template}\n\nis not present in the datsaset columns - {input.keys()}.\n\n"
-                f"Input - {input}\n\n"
-                "Continuing with the prompt as {current_example}"
-            )
+            try:
+                current_example = example_template.format_map(defaultdict(str, input))
+                logger.warn(
+                    f'\n\nKey {e} in the "example_template" in the given config'
+                    f"\n\n{example_template}\n\nis not present in the datsaset columns - {input.keys()}.\n\n"
+                    f"Input - {input}\n\n"
+                    "Continuing with the prompt as {current_example}"
+                )
+            except AttributeError as e:
+                for key in input.keys():
+                    if input[key] is not None:
+                        example_template = example_template.replace(
+                            f"{{{key}}}", input[key]
+                        )
+                current_example = example_template
 
         # populate the current example in the prompt
         prompt_template = (

--- a/src/autolabel/tasks/entity_matching.py
+++ b/src/autolabel/tasks/entity_matching.py
@@ -102,13 +102,21 @@ class EntityMatchingTask(BaseTask):
         try:
             current_example = example_template.format(**input)
         except KeyError as e:
-            current_example = example_template.format_map(defaultdict(str, input))
-            logger.warn(
-                f'\n\nKey {e} in the "example_template" in the given config'
-                f"\n\n{example_template}\n\nis not present in the datsaset columns - {input.keys()}.\n\n"
-                f"Input - {input}\n\n"
-                "Continuing with the prompt as {current_example}"
-            )
+            try:
+                current_example = example_template.format_map(defaultdict(str, input))
+                logger.warn(
+                    f'\n\nKey {e} in the "example_template" in the given config'
+                    f"\n\n{example_template}\n\nis not present in the datsaset columns - {input.keys()}.\n\n"
+                    f"Input - {input}\n\n"
+                    "Continuing with the prompt as {current_example}"
+                )
+            except AttributeError as e:
+                for key in input.keys():
+                    if input[key] is not None:
+                        example_template = example_template.replace(
+                            f"{{{key}}}", input[key]
+                        )
+                current_example = example_template
 
         # populate the current example in the prompt
         prompt_template = (

--- a/src/autolabel/tasks/multilabel_classification.py
+++ b/src/autolabel/tasks/multilabel_classification.py
@@ -94,13 +94,21 @@ class MultilabelClassificationTask(BaseTask):
         try:
             current_example = example_template.format(**input)
         except KeyError as e:
-            current_example = example_template.format_map(defaultdict(str, input))
-            logger.warn(
-                f'\n\nKey {e} in the "example_template" in the given config'
-                f"\n\n{example_template}\n\nis not present in the datsaset columns - {input.keys()}.\n\n"
-                f"Input - {input}\n\n"
-                "Continuing with the prompt as {current_example}"
-            )
+            try:
+                current_example = example_template.format_map(defaultdict(str, input))
+                logger.warn(
+                    f'\n\nKey {e} in the "example_template" in the given config'
+                    f"\n\n{example_template}\n\nis not present in the datsaset columns - {input.keys()}.\n\n"
+                    f"Input - {input}\n\n"
+                    "Continuing with the prompt as {current_example}"
+                )
+            except AttributeError as e:
+                for key in input.keys():
+                    if input[key] is not None:
+                        example_template = example_template.replace(
+                            f"{{{key}}}", input[key]
+                        )
+                current_example = example_template
 
         # populate the current example in the prompt
         prompt_template = (

--- a/src/autolabel/tasks/named_entity_recognition.py
+++ b/src/autolabel/tasks/named_entity_recognition.py
@@ -104,13 +104,21 @@ class NamedEntityRecognitionTask(BaseTask):
         try:
             current_example = example_template.format(**input)
         except KeyError as e:
-            current_example = example_template.format_map(defaultdict(str, input))
-            logger.warn(
-                f'\n\nKey {e} in the "example_template" in the given config'
-                f"\n\n{example_template}\n\nis not present in the datsaset columns - {input.keys()}.\n\n"
-                f"Input - {input}\n\n"
-                "Continuing with the prompt as {current_example}"
-            )
+            try:
+                current_example = example_template.format_map(defaultdict(str, input))
+                logger.warn(
+                    f'\n\nKey {e} in the "example_template" in the given config'
+                    f"\n\n{example_template}\n\nis not present in the datsaset columns - {input.keys()}.\n\n"
+                    f"Input - {input}\n\n"
+                    "Continuing with the prompt as {current_example}"
+                )
+            except AttributeError as e:
+                for key in input.keys():
+                    if input[key] is not None:
+                        example_template = example_template.replace(
+                            f"{{{key}}}", input[key]
+                        )
+                current_example = example_template
 
         # populate the current example in the prompt
         prompt_template = (

--- a/src/autolabel/tasks/question_answering.py
+++ b/src/autolabel/tasks/question_answering.py
@@ -95,13 +95,21 @@ class QuestionAnsweringTask(BaseTask):
         try:
             current_example = example_template.format(**input)
         except KeyError as e:
-            current_example = example_template.format_map(defaultdict(str, input))
-            logger.warn(
-                f'\n\nKey {e} in the "example_template" in the given config'
-                f"\n\n{example_template}\n\nis not present in the datsaset columns - {input.keys()}.\n\n"
-                f"Input - {input}\n\n"
-                "Continuing with the prompt as {current_example}"
-            )
+            try:
+                current_example = example_template.format_map(defaultdict(str, input))
+                logger.warn(
+                    f'\n\nKey {e} in the "example_template" in the given config'
+                    f"\n\n{example_template}\n\nis not present in the datsaset columns - {input.keys()}.\n\n"
+                    f"Input - {input}\n\n"
+                    "Continuing with the prompt as {current_example}"
+                )
+            except AttributeError as e:
+                for key in input.keys():
+                    if input[key] is not None:
+                        example_template = example_template.replace(
+                            f"{{{key}}}", input[key]
+                        )
+                current_example = example_template
 
         # populate the current example in the prompt
         prompt_template = (


### PR DESCRIPTION
# Pull Review Summary

## Description

Fallback logic in example template construction for format/format map errors. Needed for niche errors with how python string format allows for object fields to be used as template variables. Therefore, template variables with a period are treated as objects and a nonexistent field is accessed.

## Type of change

- Bug fix (change which fixes an issue)

## Tests

Tested locally