### PR TITLE
Filter multilabel confidence keys for llm labels

### DIFF
--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -332,11 +332,23 @@ class LabelingAgent:
                                     self.config.task_type()
                                     == TaskType.MULTILABEL_CLASSIFICATION
                                 ):
-                                    annotation.multilabel_confidence = (
+                                    multilabel_confidence = (
                                         self.confidence.logprob_average_per_label(
                                             model_generation=annotation
                                         )
                                     )
+                                    multilabels = (
+                                        annotation.label.split(
+                                            self.config.label_separator()
+                                        )
+                                        if annotation.label
+                                        else []
+                                    )
+                                    multilabel_confidence = {
+                                        k: v
+                                        for k, v in multilabel_confidence.items()
+                                        if k in multilabels
+                                    }
 
                             except Exception as e:
                                 logger.exception(

--- a/src/autolabel/labeler.py
+++ b/src/autolabel/labeler.py
@@ -349,6 +349,9 @@ class LabelingAgent:
                                         for k, v in multilabel_confidence.items()
                                         if k in multilabels
                                     }
+                                    annotation.multilabel_confidence = (
+                                        multilabel_confidence
+                                    )
 
                             except Exception as e:
                                 logger.exception(


### PR DESCRIPTION
# Pull Review Summary

## Description

Filter multilabel confidence keys for llm labels. Currently, the multilabel confidence may be computed for tokens that were filtered out when parsing the llm response. We don't want to include confidence for labels that were filtered out during parsing logic.

## Type of change

- Bug fix (change which fixes an issue)

## Tests

Tested confidence key filtering logic