### PR TITLE
Handle leading/trailing whitespace for labels

### DIFF
--- a/src/autolabel/confidence.py
+++ b/src/autolabel/confidence.py
@@ -116,7 +116,7 @@ class ConfidenceCalculator:
             for char in list(logprobs[i].keys())[0]:
                 if char == delimiter:
                     logprob_end_idx = i if logprob_start_idx < i else i + 1
-                    logprob_per_label[curr_label] = self.logprob_average(
+                    logprob_per_label[curr_label.strip()] = self.logprob_average(
                         logprobs[logprob_start_idx:logprob_end_idx]
                     )
                     curr_label = ""
@@ -126,7 +126,7 @@ class ConfidenceCalculator:
 
         # Average the logprobs for the last label (or only label if there is just one label)
         if logprob_start_idx < len(logprobs):
-            logprob_per_label[curr_label] = self.logprob_average(
+            logprob_per_label[curr_label.strip()] = self.logprob_average(
                 logprobs[logprob_start_idx:]
             )
         return logprob_per_label

--- a/src/autolabel/tasks/base.py
+++ b/src/autolabel/tasks/base.py
@@ -222,6 +222,7 @@ class BaseTask(ABC):
                     llm_label = self.NULL_LABEL_TOKEN
             elif self.config.task_type() == TaskType.MULTILABEL_CLASSIFICATION:
                 llm_multi_labels = llm_label.split(self.config.label_separator())
+                llm_multi_labels = list(map(str.strip, llm_multi_labels))
                 llm_multi_labels = list(
                     filter(
                         lambda label: label in self.config.labels_list(),


### PR DESCRIPTION
# Pull Review Summary

## Description

Handle leading/trailing whitespace for labels leading to missing multilabel confidence scores.

## Type of change

- Bug fix (change which fixes an issue)

## Tests

Tested locally