### PR TITLE
Validate webpage scrape URLs

### DIFF
--- a/src/autolabel/transforms/webpage_scrape.py
+++ b/src/autolabel/transforms/webpage_scrape.py
@@ -146,7 +146,7 @@ class WebpageScrape(BaseTransform):
             if not validate_url(url):
                 raise TransformError(
                     TransformErrorType.INVALID_INPUT,
-                    f"Invalid url in row {row}",
+                    f"Invalid url: {url}",
                 )
             url_response_data = await self._load_url(url)
 

--- a/src/autolabel/transforms/webpage_scrape.py
+++ b/src/autolabel/transforms/webpage_scrape.py
@@ -1,3 +1,4 @@
+from autolabel.utils import validate_url
 from autolabel.transforms.schema import (
     TransformType,
     TransformError,
@@ -142,6 +143,11 @@ class WebpageScrape(BaseTransform):
         else:
             if not urlparse(url).scheme:
                 url = f"https://{url}"
+            if not validate_url(url):
+                raise TransformError(
+                    TransformErrorType.INVALID_INPUT,
+                    f"Invalid url in row {row}",
+                )
             url_response_data = await self._load_url(url)
 
         transformed_row = {

--- a/src/autolabel/transforms/webpage_transform.py
+++ b/src/autolabel/transforms/webpage_transform.py
@@ -1,4 +1,5 @@
 from urllib.parse import urlparse
+from autolabel.utils import validate_url
 from autolabel.transforms.schema import (
     TransformType,
     TransformError,
@@ -101,6 +102,11 @@ class WebpageTransform(BaseTransform):
             )
         if not urlparse(url).scheme:
             url = f"https://{url}"
+        if not validate_url(url):
+            raise TransformError(
+                TransformErrorType.INVALID_INPUT,
+                f"Invalid url: {url}",
+            )
         url_response_text = await self._load_url(url)
 
         transformed_row = {

--- a/src/autolabel/utils.py
+++ b/src/autolabel/utils.py
@@ -426,3 +426,12 @@ def safe_serialize_to_string(data: Dict) -> Dict:
         except Exception:
             ret[k] = ""
     return ret
+
+
+def validate_url(url: str) -> bool:
+    """
+    Validate URL. Taken from https://stackoverflow.com/questions/71035383"""
+    pattern = (
+        r"^(?:https?:\/\/(?:www\.)?|https:(?:\/\/)?)?\w+(?:[-.]\w+)+(?:\/[^\/\s]+)*$"
+    )
+    return bool(re.match(pattern, url))

--- a/tests/unit/transforms/test_webpage_scrape.py
+++ b/tests/unit/transforms/test_webpage_scrape.py
@@ -79,9 +79,9 @@ async def test_unreachable_url():
     )
     assert (
         transformed_row["webpage_content"]
-        == "ENRICHMENT_TIMEOUT: Timeout when fetching content from URL"
+        == "INVALID_INPUT: Invalid url: http://portal.net.kp/"
     )
     assert (
         transformed_row["webpage_content_error"]
-        == "ENRICHMENT_TIMEOUT: Timeout when fetching content from URL"
+        == "INVALID_INPUT: Invalid url: http://portal.net.kp/"
     )


### PR DESCRIPTION
# Pull Review Summary

## Description

Validate webpage scrape URLs using regex. The motivation is to avoid making web scrape requests unnecessarily when the URL is invalid. It is possible that there may be some URL's for which this regex match does not validate correctly. However, these cases should be very niche and this change will avoid several unnecessary web scrape requests for a number of cases where the URL is obviously invalid.

## Type of change

- New feature (change which adds functionality)

## Tests

Tested locally with common valid and invalid URL's/patterns