### PR TITLE
Skip adding start/end tuple if key not found

### DIFF
--- a/src/autolabel/confidence.py
+++ b/src/autolabel/confidence.py
@@ -192,9 +192,10 @@ class ConfidenceCalculator:
                 # We did not find the key in the logprobs so we set its confidence as 0
                 # This should not be possible if the LLM followed its guidelines.
                 logprob_per_key[key] = 0
-            start_token = mapping[loc]
-            end_token = mapping[loc + len(key_to_find) - 1]
-            locations.append((start_token, end_token, key))
+            else:
+                start_token = mapping[loc]
+                end_token = mapping[loc + len(key_to_find) - 1]
+                locations.append((start_token, end_token, key))
         locations.sort()
         # Here, the locations consist of the start and end *token* indices for each key
         # i.e for the keys A and B, we find the start and end tokens where they are found in the logprobs list


### PR DESCRIPTION
This bug leads to out of index errors - https://refuel-ai.sentry.io/issues/5903416506/?alert_rule_id=14647036&alert_type=issue&notification_uuid=a206b1ca-88a1-485b-b2f9-c6cb3ef899f4&project=4505830328172544&referrer=slack