### PR TITLE
Modify get_cost to account for prompt caching

### DIFF
--- a/src/autolabel/models/anthropic.py
+++ b/src/autolabel/models/anthropic.py
@@ -105,7 +105,7 @@ class AnthropicLLM(BaseModel):
                 latencies=[0 for _ in prompts],
             )
 
-    def get_cost(self, prompt: str, label: Optional[str] = "") -> float:
+    def get_cost(self, prompt: str, label: Optional[str] = "", llm_output: Optional[Dict] = None) -> float:
         num_prompt_toks = len(self.tokenizer.encode(prompt).ids)
         if label:
             num_label_toks = len(self.tokenizer.encode(label).ids)

--- a/src/autolabel/models/base.py
+++ b/src/autolabel/models/base.py
@@ -50,7 +50,11 @@ class BaseModel(ABC):
                 new_results = self._label(missing_prompts, output_schema)
             for ind, prompt in enumerate(missing_prompts):
                 costs.append(
-                    self.get_cost(prompt, label=new_results.generations[ind][0].text)
+                    self.get_cost(
+                        prompt,
+                        label=new_results.generations[ind][0].text,
+                        llm_output=new_results.llm_output,
+                    )
                 )
 
             # Set the existing prompts to the new results
@@ -77,7 +81,9 @@ class BaseModel(ABC):
         pass
 
     @abstractmethod
-    def get_cost(self, prompt: str, label: Optional[str] = "") -> float:
+    def get_cost(
+        self, prompt: str, label: Optional[str] = "", llm_output: Optional[Dict] = None
+    ) -> float:
         pass
 
     def get_cached_prompts(self, prompts: List[str]) -> Optional[str]:

--- a/src/autolabel/models/cohere.py
+++ b/src/autolabel/models/cohere.py
@@ -66,7 +66,9 @@ class CohereLLM(BaseModel):
                 latencies=[0 for _ in prompts],
             )
 
-    def get_cost(self, prompt: str, label: Optional[str] = "") -> float:
+    def get_cost(
+        self, prompt: str, label: Optional[str] = "", llm_output: Optional[Dict] = None
+    ) -> float:
         num_prompt_toks = len(self.co.tokenize(prompt).tokens)
         if label:
             num_label_toks = len(self.co.tokenize(label).tokens)

--- a/src/autolabel/models/google.py
+++ b/src/autolabel/models/google.py
@@ -151,7 +151,9 @@ class GoogleLLM(BaseModel):
                 latencies=[0 for _ in prompts],
             )
 
-    def get_cost(self, prompt: str, label: Optional[str] = "") -> float:
+    def get_cost(
+        self, prompt: str, label: Optional[str] = "", llm_output: Optional[Dict] = None
+    ) -> float:
         if self.model_name is None:
             return 0.0
         cost_per_prompt_token = self.COST_PER_PROMPT_TOKEN[self.model_name]

--- a/src/autolabel/models/hf_pipeline.py
+++ b/src/autolabel/models/hf_pipeline.py
@@ -116,7 +116,9 @@ class HFPipelineLLM(BaseModel):
                 latencies=[0 for _ in prompts],
             )
 
-    def get_cost(self, prompt: str, label: Optional[str] = "") -> float:
+    def get_cost(
+        self, prompt: str, label: Optional[str] = "", llm_output: Optional[Dict] = None
+    ) -> float:
         # Model inference for this model is being run locally
         # Revisit this in the future when we support HF inference endpoints
         return 0.0

--- a/src/autolabel/models/hf_pipeline_vision.py
+++ b/src/autolabel/models/hf_pipeline_vision.py
@@ -107,7 +107,9 @@ class HFPipelineMultimodal(BaseModel):
             generations=generations, errors=[None] * len(generations)
         )
 
-    def get_cost(self, prompt: str, label: Optional[str] = "") -> float:
+    def get_cost(
+        self, prompt: str, label: Optional[str] = "", llm_output: Optional[Dict] = None
+    ) -> float:
         # Model inference for this model is being run locally
         # Revisit this in the future when we support HF inference endpoints
         return 0.0

--- a/src/autolabel/models/mistral.py
+++ b/src/autolabel/models/mistral.py
@@ -197,7 +197,9 @@ class MistralLLM(BaseModel):
             generations=generations, errors=errors, latencies=latencies
         )
 
-    def get_cost(self, prompt: str, label: Optional[str] = "") -> float:
+    def get_cost(
+        self, prompt: str, label: Optional[str] = "", llm_output: Optional[Dict] = None
+    ) -> float:
         cost_per_prompt_char = self.COST_PER_PROMPT_TOKEN[self.model_name]
         cost_per_completion_char = self.COST_PER_COMPLETION_TOKEN[self.model_name]
         return cost_per_prompt_char * len(prompt) + cost_per_completion_char * (

--- a/src/autolabel/models/openai_vision.py
+++ b/src/autolabel/models/openai_vision.py
@@ -136,7 +136,9 @@ class OpenAIVisionLLM(BaseModel):
             latencies=[time() - start_time] * len(generations),
         )
 
-    def get_cost(self, prompt: str, label: Optional[str] = "") -> float:
+    def get_cost(
+        self, prompt: str, label: Optional[str] = "", llm_output: Optional[Dict] = None
+    ) -> float:
         encoding = self.tiktoken.encoding_for_model(self.model_name)
         num_prompt_toks = len(encoding.encode(prompt))
         if label:

--- a/src/autolabel/models/refuelV2.py
+++ b/src/autolabel/models/refuelV2.py
@@ -279,7 +279,9 @@ class RefuelLLMV2(BaseModel):
                     curr_schema[key] = self._prepare_output_schema(curr_schema[key])
         return curr_schema
 
-    def get_cost(self, prompt: str, label: Optional[str] = "") -> float:
+    def get_cost(
+        self, prompt: str, label: Optional[str] = "", llm_output: Optional[Dict] = None
+    ) -> float:
         return 0
 
     def returns_token_probs(self) -> bool:

--- a/src/autolabel/models/vllm.py
+++ b/src/autolabel/models/vllm.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from autolabel.models import BaseModel
 from autolabel.configs import AutolabelConfig
@@ -115,7 +115,9 @@ class VLLMModel(BaseModel):
             resp.append({curr_logprob_obj.decoded_token: curr_logprob_obj.logprob})
         return resp
 
-    def get_cost(self, prompt: str, label: Optional[str] = "") -> float:
+    def get_cost(
+        self, prompt: str, label: Optional[str] = "", llm_output: Optional[Dict] = None
+    ) -> float:
         return 0
 
     def returns_token_probs(self) -> bool:

--- a/src/autolabel/schema.py
+++ b/src/autolabel/schema.py
@@ -199,6 +199,9 @@ class RefuelLLMResult(BaseModel):
 
     generations: List[List[Union[Generation, ChatGeneration]]]
 
+    """Arbitrary LLM provider-specific output."""
+    llm_output: Optional[dict] = None
+
     """Errors encountered while running the labeling job"""
     errors: List[Optional[LabelingError]]
 


### PR DESCRIPTION
OpenAI supports prompt caching by default for gpt-4o-2024-08-06 and gpt-4o-mini-2024-07-18.
When using the cached prompts, it'll automatically apply 50% discount to the cached prompt tokens.
Making that adjustment to the get_cost to account for this discount.

Testing:
Tested using model gpt-4o-2024-08-06