### PR TITLE
Support few shot for large label taxonomy

### DIFF
--- a/src/autolabel/tasks/attribute_extraction.py
+++ b/src/autolabel/tasks/attribute_extraction.py
@@ -167,6 +167,21 @@ class AttributeExtractionTask(BaseTask):
     ) -> Tuple[str, str]:
         fmt_task_guidelines = self.task_guidelines
 
+        # add additional labels to the selected_labels_map for attributes
+        # if they are present in the few shot examples
+        if self._is_few_shot_mode() and selected_labels_map:
+            for eg in examples:
+                for attribute_name in selected_labels_map:
+                    if (
+                        attribute_name in eg
+                        and eg.get(attribute_name)
+                        and eg.get(attribute_name)
+                        not in selected_labels_map[attribute_name]
+                    ):
+                        selected_labels_map[attribute_name].append(
+                            eg.get(attribute_name)
+                        )
+
         attribute_json, output_schema = self._construct_attribute_json(
             selected_labels_map=selected_labels_map
         )


### PR DESCRIPTION
Support few shot for large label taxonomy by just adding to the retrieved labels in case of few shot. This means that lets say we retrieved 10 labels and have few shot set to 5. If the 5 labels are independent to the 10 retrieved labels, we will be sending 15 labels to the attribute_options.