### PR TITLE
Serialize field outputs correctly

### DIFF
--- a/src/autolabel/tasks/attribute_extraction.py
+++ b/src/autolabel/tasks/attribute_extraction.py
@@ -287,7 +287,9 @@ class AttributeExtractionTask(BaseTask):
             completion_text = completion_text.lstrip("```json")
             completion_text = completion_text.rstrip("```")
 
-            llm_label = {k: json.dumps(v) for k, v in json5.loads(completion_text).items()}
+            llm_label = {
+                k: json.dumps(v) for k, v in json5.loads(completion_text).items()
+            }
             successfully_labeled = True
         except Exception as e:
             logger.error(f"Error parsing LLM response: {response.text}, Error: {e}")

--- a/src/autolabel/tasks/attribute_extraction.py
+++ b/src/autolabel/tasks/attribute_extraction.py
@@ -286,10 +286,12 @@ class AttributeExtractionTask(BaseTask):
             # Remove markdown formatting from the completion text
             completion_text = completion_text.lstrip("```json")
             completion_text = completion_text.rstrip("```")
-
-            llm_label = {
-                k: json.dumps(v) for k, v in json5.loads(completion_text).items()
-            }
+            llm_label = {}
+            for k, v in json5.loads(completion_text).items():
+                if isinstance(v, list) or isinstance(v, dict):
+                    llm_label[k] = json.dumps(v)
+                else:
+                    llm_label[k] = str(v)
             successfully_labeled = True
         except Exception as e:
             logger.error(f"Error parsing LLM response: {response.text}, Error: {e}")


### PR DESCRIPTION
The issue currently is that if v is an object (e.g. a dict or list), str(v)  just serializes it as a string, but the resulting string might not always a valid json:
s = """{'k': 'v', 'k2': {'inner_k': 'inner_v'}, 'k3': false}"""

json5.loads(s)
{'k': 'v', 'k2': {'inner_k': 'inner_v'}, 'k3': False}

print(json.dumps(json5.loads(s)))
{"k": "v", "k2": {"inner_k": "inner_v"}, "k3": false}
^ this is a valid json

print(str(json5.loads(s)))
{'k': 'v', 'k2': {'inner_k': 'inner_v'}, 'k3': False}
^this is not a valid json

in order to correctly serialize the respons